### PR TITLE
skip over capsules read from the request stream

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,23 @@
+package masque
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapsuleSkipping(t *testing.T) {
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	var buf bytes.Buffer
+	require.NoError(t, http3.WriteCapsule(&buf, 1337, []byte("foo")))
+	require.NoError(t, http3.WriteCapsule(&buf, 42, []byte("bar")))
+	require.ErrorIs(t, skipCapsules(&buf), io.EOF)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/dunglas/httpsfv v1.0.2
-	github.com/quic-go/quic-go v0.43.0
+	github.com/quic-go/quic-go v0.43.1-0.20240503111418-8de22b2468d2
 	github.com/stretchr/testify v1.9.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/quic-go v0.43.0 h1:sjtsTKWX0dsHpuMJvLxGqoQdtgJnbAPWY+W+5vjYW/g=
-github.com/quic-go/quic-go v0.43.0/go.mod h1:132kz4kL3F9vxhW3CtQJLDVwcFe5wdWeJXXijhsO57M=
+github.com/quic-go/quic-go v0.43.1-0.20240503111418-8de22b2468d2 h1:8KMsHUaWBAE7+rzZErj2ewXsvOvm3Sv019Itdd9ohEg=
+github.com/quic-go/quic-go v0.43.1-0.20240503111418-8de22b2468d2/go.mod h1:132kz4kL3F9vxhW3CtQJLDVwcFe5wdWeJXXijhsO57M=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Updates quic-go to a version on `master` that includes https://github.com/quic-go/quic-go/pull/4476.