### PR TITLE
introduce a connect-udp address type

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
 coverage:
   ignore:
     - cmd/
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/conn.go
+++ b/conn.go
@@ -14,6 +14,13 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
+type masqueAddr struct{ net.Addr }
+
+func (m masqueAddr) Network() string { return "connect-udp" }
+func (m masqueAddr) String() string  { return m.Addr.String() }
+
+var _ net.Addr = &masqueAddr{}
+
 type proxiedConn struct {
 	str        http3.Stream
 	localAddr  net.Addr
@@ -71,7 +78,7 @@ func (c *proxiedConn) Close() error {
 }
 
 func (c *proxiedConn) LocalAddr() net.Addr {
-	return c.localAddr
+	return &masqueAddr{c.localAddr}
 }
 
 func (c *proxiedConn) SetDeadline(t time.Time) error {


### PR DESCRIPTION
I'm not sure if this is the right thing to do.

For the moment, it prevents quic-go from misidentifying the inner and the outer connection: https://github.com/quic-go/quic-go/blob/e90a0d4e03d1f1047344b79ac1c63a1873ebcd26/multiplexer.go#L54-L60. Maybe it's time to remove this check?