### PR TITLE
increase the initial packet size to 1350 bytes

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,10 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
+// defaultInitialPacketSize is an increased packet size used for the connection to the proxy.
+// This allows tunneling QUIC connections, which themselves have a minimum MTU requirement of 1200 bytes.
+const defaultInitialPacketSize = 1350
+
 type Client struct {
 	Template        *uritemplate.Template
 	TLSClientConfig *tls.Config
@@ -46,7 +50,10 @@ func (c *Client) DialIP(ctx context.Context, raddr *net.UDPAddr) (net.PacketConn
 	c.dialOnce.Do(func() {
 		quicConf := c.QUICConfig
 		if quicConf == nil {
-			quicConf = &quic.Config{EnableDatagrams: true}
+			quicConf = &quic.Config{
+				EnableDatagrams:   true,
+				InitialPacketSize: defaultInitialPacketSize,
+			}
 		}
 		if !quicConf.EnableDatagrams {
 			c.dialErr = errors.New("masque: QUICConfig needs to enable Datagrams")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/dunglas/httpsfv v1.0.2
-	github.com/quic-go/quic-go v0.43.1-0.20240505021535-bb6f066aa56f
+	github.com/quic-go/quic-go v0.43.1-0.20240509044108-f3d76b39bfb7
 	github.com/stretchr/testify v1.9.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/quic-go v0.43.1-0.20240505021535-bb6f066aa56f h1:gTRVbWuTMyzCbbq99V+O8VhbK076dzQZ0+3t2Jsy88c=
-github.com/quic-go/quic-go v0.43.1-0.20240505021535-bb6f066aa56f/go.mod h1:132kz4kL3F9vxhW3CtQJLDVwcFe5wdWeJXXijhsO57M=
+github.com/quic-go/quic-go v0.43.1-0.20240509044108-f3d76b39bfb7 h1:g6cZHBnu3wdPritIhkwNz7zTHO+rNRn5iedD3BXg49Y=
+github.com/quic-go/quic-go v0.43.1-0.20240509044108-f3d76b39bfb7/go.mod h1:132kz4kL3F9vxhW3CtQJLDVwcFe5wdWeJXXijhsO57M=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Updates quic-go to a commit on `master` that includes https://github.com/quic-go/quic-go/pull/4503.