### PR TITLE
change the return value of DialTarget to a net.PacketConn

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -165,7 +165,7 @@ func TestProxyDialFailure(t *testing.T) {
 	s := Proxy{
 		Server:   http3.Server{Handler: http.NewServeMux()},
 		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
-		DialTarget: func(addr *net.UDPAddr) (*net.UDPConn, error) {
+		DialTarget: func(addr *net.UDPAddr) (net.PacketConn, error) {
 			dialedAddr = addr
 			return nil, testErr
 		},


### PR DESCRIPTION
This allows the callback to return connections that are not necessarily a *net.UDPConn.