### PR TITLE
pass the request context to Proxy.DialTarget

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -59,7 +59,7 @@ type Proxy struct {
 	// DialTarget is called when the proxy needs to open a new UDP socket to the target server.
 	// It must return a connected UDP socket.
 	// TODO(#3): support unconnected sockets.
-	DialTarget func(*net.UDPAddr) (*net.UDPConn, error)
+	DialTarget func(context.Context, *net.UDPAddr) (*net.UDPConn, error)
 
 	closed atomic.Bool
 
@@ -134,7 +134,7 @@ func (s *Proxy) Upgrade(w http.ResponseWriter, r *http.Request) error {
 	if s.DialTarget == nil {
 		conn, err = net.DialUDP("udp", nil, addr)
 	} else {
-		conn, err = s.DialTarget(addr)
+		conn, err = s.DialTarget(r.Context(), addr)
 	}
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -165,7 +165,7 @@ func TestProxyDialFailure(t *testing.T) {
 	s := Proxy{
 		Server:   http3.Server{Handler: http.NewServeMux()},
 		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
-		DialTarget: func(addr *net.UDPAddr) (*net.UDPConn, error) {
+		DialTarget: func(_ context.Context, addr *net.UDPAddr) (*net.UDPConn, error) {
 			dialedAddr = addr
 			return nil, testErr
 		},


### PR DESCRIPTION
Opening a UDP connection should usually be instantaneous, but this isn't guaranteed, especially if we want to allow for chained operation in the future. It makes sense to pass the request context here.