### PR TITLE
don't embed a http3.Server in the Proxy

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -39,15 +39,14 @@ func main() {
 	tlsConf := http3.ConfigureTLSConfig(&tls.Config{
 		Certificates: []tls.Certificate{cert},
 	})
-	proxy := masque.Proxy{
-		Template: template,
-		Server: http3.Server{
-			Addr:            bind,
-			TLSConfig:       tlsConf,
-			EnableDatagrams: true,
-			Logger:          slog.Default(),
-		},
+	server := http3.Server{
+		Addr:            bind,
+		TLSConfig:       tlsConf,
+		EnableDatagrams: true,
+		Logger:          slog.Default(),
 	}
+	defer server.Close()
+	proxy := masque.Proxy{Template: template}
 	// parse the template to extract the path for the HTTP handler
 	u, err := url.Parse(templateStr)
 	if err != nil {
@@ -60,7 +59,7 @@ func main() {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	if err := proxy.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("failed to run proxy: %v", err)
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -47,8 +47,6 @@ type proxyEntry struct {
 }
 
 type Proxy struct {
-	http3.Server
-
 	// Template is the URI template that clients will use to configure this UDP proxy.
 	Template *uritemplate.Template
 
@@ -211,7 +209,6 @@ func (s *Proxy) proxyConnReceive(conn *net.UDPConn, str http3.Stream) error {
 
 func (s *Proxy) Close() error {
 	s.closed.Store(true)
-	err := s.Server.Close()
 	s.mx.Lock()
 	for entry := range s.conns {
 		entry.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
@@ -221,5 +218,5 @@ func (s *Proxy) Close() error {
 	s.conns = nil
 	s.mx.Unlock()
 	s.refCount.Wait()
-	return err
+	return nil
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -44,9 +44,7 @@ var _ http3.HTTPStreamer = &http3ResponseWriter{}
 func (s *http3ResponseWriter) HTTPStream() http3.Stream { return s.str }
 
 func TestUpgradeFailures(t *testing.T) {
-	mux := http.NewServeMux()
 	s := Proxy{
-		Server:   http3.Server{Handler: mux},
 		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
 	}
 
@@ -113,7 +111,6 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 	require.NoError(t, err)
 
 	s := Proxy{
-		Server:   http3.Server{Handler: http.NewServeMux()},
 		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
 	}
 	req := newRequest(fmt.Sprintf("https://localhost:1234/masque?h=localhost&p=%d", remoteServerConn.LocalAddr().(*net.UDPAddr).Port))
@@ -163,7 +160,6 @@ func TestProxyDialFailure(t *testing.T) {
 	var dialedAddr *net.UDPAddr
 	testErr := errors.New("test error")
 	s := Proxy{
-		Server:   http3.Server{Handler: http.NewServeMux()},
 		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
 		DialTarget: func(_ context.Context, addr *net.UDPAddr) (*net.UDPConn, error) {
 			dialedAddr = addr


### PR DESCRIPTION
The proxy isn't doing anything with the `http3.Server`. There's no reason to embed it.