### PR TITLE
make ParseRequest a top-level function

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -47,14 +47,14 @@ func main() {
 		Logger:          slog.Default(),
 	}
 	defer server.Close()
-	proxy := masque.Proxy{Template: template}
+	proxy := masque.Proxy{}
 	// parse the template to extract the path for the HTTP handler
 	u, err := url.Parse(templateStr)
 	if err != nil {
 		log.Fatalf("failed to parse URI template: %v", err)
 	}
 	http.HandleFunc(u.Path, func(w http.ResponseWriter, r *http.Request) {
-		req, err := proxy.ParseRequest(r)
+		req, err := masque.ParseRequest(r, template)
 		if err != nil {
 			var perr *masque.RequestParseError
 			if errors.As(err, &perr) {

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -60,12 +60,10 @@ func TestProxying(t *testing.T) {
 		Handler:         mux,
 	}
 	defer server.Close()
-	proxy := masque.Proxy{
-		Template: template,
-	}
+	proxy := masque.Proxy{}
 	defer proxy.Close()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := proxy.ParseRequest(r)
+		req, err := masque.ParseRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -113,11 +111,9 @@ func TestProxyShutdown(t *testing.T) {
 		Handler:         mux,
 	}
 	defer server.Close()
-	proxy := masque.Proxy{
-		Template: template,
-	}
+	proxy := masque.Proxy{}
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := proxy.ParseRequest(r)
+		req, err := masque.ParseRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/proxy.go
+++ b/proxy.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/url"
-	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 
 	"github.com/dunglas/httpsfv"
-	"github.com/yosida95/uritemplate/v3"
 )
 
 const (
@@ -45,93 +42,12 @@ type proxyEntry struct {
 	conn *net.UDPConn
 }
 
-// Request is returned from Proxy.ParseRequest.
-// Target is the target server that the client requests to connect to.
-// It can either be DNS name:port or an IP:port.
-type Request struct {
-	Target string
-}
-
-// RequestParseError is returned from Proxy.ParseRequest if parsing the CONNECT-UDP request fails.
-// It is recommended that the request is rejected with the corresponding HTTP status code.
-type RequestParseError struct {
-	HTTPStatus int
-	Err        error
-}
-
-func (e *RequestParseError) Error() string { return e.Err.Error() }
-func (e *RequestParseError) Unwrap() error { return e.Err }
-
 type Proxy struct {
-	// Template is the URI template that clients will use to configure this UDP proxy.
-	Template *uritemplate.Template
-
 	closed atomic.Bool
 
 	mx       sync.Mutex
 	refCount sync.WaitGroup // counter for the Go routines spawned in Upgrade
 	conns    map[proxyEntry]struct{}
-}
-
-func (s *Proxy) ParseRequest(r *http.Request) (*Request, error) {
-	if r.Method != http.MethodConnect {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusMethodNotAllowed,
-			Err:        fmt.Errorf("expected CONNECT request, got %s", r.Method),
-		}
-	}
-	if r.Proto != requestProtocol {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusNotImplemented,
-			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
-		}
-	}
-	// TODO: check :authority
-	capsuleHeaderValues, ok := r.Header[capsuleHeader]
-	if !ok {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("missing Capsule-Protocol header"),
-		}
-	}
-	item, err := httpsfv.UnmarshalItem(capsuleHeaderValues)
-	if err != nil {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("invalid capsule header value: %s", capsuleHeaderValues),
-		}
-	}
-	if v, ok := item.Value.(int64); !ok || v != 1 {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("incorrect capsule header value: %d", v),
-		}
-	}
-
-	match := s.Template.Match(r.URL.String())
-	targetHostEncoded := match.Get(uriTemplateTargetHost).String()
-	targetPortStr := match.Get(uriTemplateTargetPort).String()
-	if targetHostEncoded == "" || targetPortStr == "" {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("expected target_host and target_port"),
-		}
-	}
-	targetHost, err := url.QueryUnescape(targetHostEncoded)
-	if err != nil {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("failed to decode target_host: %w", err),
-		}
-	}
-	targetPort, err := strconv.Atoi(targetPortStr)
-	if err != nil {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusBadRequest,
-			Err:        fmt.Errorf("failed to decode target_port: %w", err),
-		}
-	}
-	return &Request{Target: fmt.Sprintf("%s:%d", targetHost, targetPort)}, nil
 }
 
 // Proxy proxies a request on a newly created connected UDP socket.

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -43,66 +43,6 @@ var _ http3.HTTPStreamer = &http3ResponseWriter{}
 
 func (s *http3ResponseWriter) HTTPStream() http3.Stream { return s.str }
 
-func TestUpgradeFailures(t *testing.T) {
-	s := Proxy{
-		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
-	}
-
-	t.Run("wrong request method", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
-		req.Method = http.MethodHead
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "expected CONNECT request, got HEAD")
-		require.Equal(t, http.StatusMethodNotAllowed, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("wrong protocol", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
-		req.Proto = "not-connect-udp"
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "unexpected protocol: not-connect-udp")
-		require.Equal(t, http.StatusNotImplemented, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("missing Capsule-Protocol header", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
-		req.Header.Del("Capsule-Protocol")
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "missing Capsule-Protocol header")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("invalid Capsule-Protocol header", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
-		req.Header.Set("Capsule-Protocol", "🤡")
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "invalid capsule header value: [🤡]")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("invalid Capsule-Protocol header value", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
-		req.Header.Set("Capsule-Protocol", "2")
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "incorrect capsule header value: 2")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("missing target host", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=&p=1234")
-		_, err := s.ParseRequest(req)
-		require.EqualError(t, err, "expected target_host and target_port")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
-	})
-
-	t.Run("invalid target port", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=localhost&p=foobar")
-		_, err := s.ParseRequest(req)
-		require.ErrorContains(t, err, "failed to decode target_port")
-		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
-	})
-}
-
 func TestProxyCloseProxiedConn(t *testing.T) {
 	testDone := make(chan struct{})
 	defer close(testDone)
@@ -110,9 +50,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 	remoteServerConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	require.NoError(t, err)
 
-	s := Proxy{
-		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
-	}
+	s := Proxy{}
 	req := newRequest(fmt.Sprintf("https://localhost:1234/masque?h=localhost&p=%d", remoteServerConn.LocalAddr().(*net.UDPAddr).Port))
 	rec := httptest.NewRecorder()
 	done := make(chan struct{})
@@ -135,7 +73,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 		<-closeStream
 		return 0, io.EOF
 	})
-	r, err := s.ParseRequest(req)
+	r, err := ParseRequest(req, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
 	go s.Proxy(&http3ResponseWriter{ResponseWriter: rec, str: str}, r)
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -159,11 +97,9 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 }
 
 func TestProxyDialFailure(t *testing.T) {
-	s := Proxy{
-		Template: uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
-	}
+	s := Proxy{}
 	r := newRequest("https://localhost:1234/masque?h=localhost&p=70000") // invalid port number
-	req, err := s.ParseRequest(r)
+	req, err := ParseRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 

--- a/request.go
+++ b/request.go
@@ -1,0 +1,91 @@
+package masque
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/dunglas/httpsfv"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+// Request is the parsed CONNECT-UDP request returned from ParseRequest.
+// Target is the target server that the client requests to connect to.
+// It can either be DNS name:port or an IP:port.
+type Request struct {
+	Target string
+}
+
+// RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
+// It is recommended that the request is rejected with the corresponding HTTP status code.
+type RequestParseError struct {
+	HTTPStatus int
+	Err        error
+}
+
+func (e *RequestParseError) Error() string { return e.Err.Error() }
+func (e *RequestParseError) Unwrap() error { return e.Err }
+
+// ParseRequest parses a CONNECT-UDP request.
+// The template is the URI template that clients will use to configure this UDP proxy.
+func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, error) {
+	if r.Method != http.MethodConnect {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusMethodNotAllowed,
+			Err:        fmt.Errorf("expected CONNECT request, got %s", r.Method),
+		}
+	}
+	if r.Proto != requestProtocol {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusNotImplemented,
+			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
+		}
+	}
+	// TODO: check :authority
+	capsuleHeaderValues, ok := r.Header[capsuleHeader]
+	if !ok {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("missing Capsule-Protocol header"),
+		}
+	}
+	item, err := httpsfv.UnmarshalItem(capsuleHeaderValues)
+	if err != nil {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("invalid capsule header value: %s", capsuleHeaderValues),
+		}
+	}
+	if v, ok := item.Value.(int64); !ok || v != 1 {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("incorrect capsule header value: %d", v),
+		}
+	}
+
+	match := template.Match(r.URL.String())
+	targetHostEncoded := match.Get(uriTemplateTargetHost).String()
+	targetPortStr := match.Get(uriTemplateTargetPort).String()
+	if targetHostEncoded == "" || targetPortStr == "" {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("expected target_host and target_port"),
+		}
+	}
+	targetHost, err := url.QueryUnescape(targetHostEncoded)
+	if err != nil {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("failed to decode target_host: %w", err),
+		}
+	}
+	targetPort, err := strconv.Atoi(targetPortStr)
+	if err != nil {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusBadRequest,
+			Err:        fmt.Errorf("failed to decode target_port: %w", err),
+		}
+	}
+	return &Request{Target: fmt.Sprintf("%s:%d", targetHost, targetPort)}, nil
+}

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,67 @@
+package masque
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+func TestRequestParsing(t *testing.T) {
+	template := uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}")
+
+	t.Run("wrong request method", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque")
+		req.Method = http.MethodHead
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "expected CONNECT request, got HEAD")
+		require.Equal(t, http.StatusMethodNotAllowed, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("wrong protocol", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque")
+		req.Proto = "not-connect-udp"
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "unexpected protocol: not-connect-udp")
+		require.Equal(t, http.StatusNotImplemented, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("missing Capsule-Protocol header", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque")
+		req.Header.Del("Capsule-Protocol")
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "missing Capsule-Protocol header")
+		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("invalid Capsule-Protocol header", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque")
+		req.Header.Set("Capsule-Protocol", "🤡")
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "invalid capsule header value: [🤡]")
+		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("invalid Capsule-Protocol header value", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque")
+		req.Header.Set("Capsule-Protocol", "2")
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "incorrect capsule header value: 2")
+		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("missing target host", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque?h=&p=1234")
+		_, err := ParseRequest(req, template)
+		require.EqualError(t, err, "expected target_host and target_port")
+		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+
+	t.Run("invalid target port", func(t *testing.T) {
+		req := newRequest("https://localhost:1234/masque?h=localhost&p=foobar")
+		_, err := ParseRequest(req, template)
+		require.ErrorContains(t, err, "failed to decode target_port")
+		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+}


### PR DESCRIPTION
Follow-up to #46.

This makes it clear that parsing a request doesn't have any side effects. It allows running a proxy that accepts CONNECT-UDP requests using multiple different templates.