### PR TITLE
add a DialAddr method to the client

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -38,7 +38,7 @@ func TestReadDeadline(t *testing.T) {
 			<-done
 			return 0, errors.New("test done")
 		}).MaxTimes(1)
-		return str, newProxiedConn(str, nil, nil)
+		return str, newProxiedConn(str, nil)
 	}
 
 	t.Run("read after deadline", func(t *testing.T) {


### PR DESCRIPTION
Fixes #49.

This change means that we don't have anything meaningful to return from `proxiedConn.RemoteAddr`, since we never learn the target's IP address. It seems like there's nothing we can do about it. The right thing to return would be the host name we dialed, but that doesn't fit into the `net.PacketConn` abstraction.

Once we implement support for the RFC 9209 Proxy Status headers (see #2), we can fill in the value the proxy sent. But there's no guarantee that 1. the proxy sends this header value and 2. that the value is correct.