### PR TITLE
fix incorrect type of Capsule-Protocol header

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -2,7 +2,6 @@ package masque
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -13,29 +12,12 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/quic-go/quic-go/quicvarint"
-
-	"github.com/dunglas/httpsfv"
-)
-
-const (
-	requestProtocol = "connect-udp"
-	capsuleHeader   = "Capsule-Protocol"
 )
 
 const (
 	uriTemplateTargetHost = "target_host"
 	uriTemplateTargetPort = "target_port"
 )
-
-var capsuleProtocolHeaderValue string
-
-func init() {
-	v, err := httpsfv.Marshal(httpsfv.NewItem(1))
-	if err != nil {
-		panic(fmt.Sprintf("failed to marshal capsule protocol header value: %v", err))
-	}
-	capsuleProtocolHeaderValue = v
-}
 
 type proxyEntry struct {
 	str  http3.Stream

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -30,7 +30,7 @@ func newRequest(target string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, target, nil)
 	req.Method = http.MethodConnect
 	req.Proto = requestProtocol
-	req.Header.Add("Capsule-Protocol", "1")
+	req.Header.Add("Capsule-Protocol", capsuleProtocolHeaderValue)
 	return req
 }
 


### PR DESCRIPTION
The required value is `?1`. According to the structured HTTP field specification (RFC 8941, section 3.3.6) this is a bool, and not an integer.