### PR TITLE
fix missing context ID in datagrams

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -56,7 +56,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 	done := make(chan struct{})
 	str := NewMockStream(gomock.NewController(t))
 	str.EXPECT().ReceiveDatagram(gomock.Any()).DoAndReturn(func(context.Context) ([]byte, error) {
-		return []byte("foo"), nil
+		return append(contextIDZero, []byte("foo")...), nil
 	})
 	// This datagram is received after the connection is closed.
 	// We expect that it won't get sent on.


### PR DESCRIPTION
For UDP payloads, the context ID is 0, see section 5 of RFC 9298.