### PR TITLE
implement parsing of the CONNECT-IP request

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,8 +52,8 @@ func (c *Client) DialAddr(ctx context.Context, target string) (net.PacketConn, *
 		return nil, nil, fmt.Errorf("failed to parse target: %w", err)
 	}
 	str, err := c.Template.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(host),
-		uriTemplateTargetPort: uritemplate.String(port),
+		connectUDPTemplateTargetHost: uritemplate.String(host),
+		connectUDPTemplateTargetPort: uritemplate.String(port),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
@@ -67,8 +67,8 @@ func (c *Client) Dial(ctx context.Context, raddr *net.UDPAddr) (net.PacketConn, 
 		return nil, nil, errors.New("masque: no template")
 	}
 	str, err := c.Template.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(escape(raddr.IP.String())),
-		uriTemplateTargetPort: uritemplate.String(strconv.Itoa(raddr.Port)),
+		connectUDPTemplateTargetHost: uritemplate.String(escape(raddr.IP.String())),
+		connectUDPTemplateTargetPort: uritemplate.String(strconv.Itoa(raddr.Port)),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
@@ -134,7 +134,7 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string) (net.PacketC
 	}
 	if err := rstr.SendRequestHeader(&http.Request{
 		Method: http.MethodConnect,
-		Proto:  requestProtocol,
+		Proto:  connectUDPRequestProtocol,
 		Host:   u.Host,
 		Header: http.Header{capsuleHeader: []string{capsuleProtocolHeaderValue}},
 		URL:    u,

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -54,7 +54,7 @@ func main() {
 		log.Fatalf("failed to parse URI template: %v", err)
 	}
 	http.HandleFunc(u.Path, func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseConnectUDPRequest(r, template)
 		if err != nil {
 			var perr *masque.RequestParseError
 			if errors.As(err, &perr) {

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -68,7 +68,7 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 	proxy := masque.Proxy{}
 	defer proxy.Close()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseConnectUDPRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -119,7 +119,7 @@ func TestProxyToHostname(t *testing.T) {
 	proxy := masque.Proxy{}
 	defer proxy.Close()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseConnectUDPRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -221,7 +221,7 @@ func TestProxyShutdown(t *testing.T) {
 	defer server.Close()
 	proxy := masque.Proxy{}
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseConnectUDPRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/proxy.go
+++ b/proxy.go
@@ -14,11 +14,6 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
-const (
-	uriTemplateTargetHost = "target_host"
-	uriTemplateTargetPort = "target_port"
-)
-
 var contextIDZero = quicvarint.Append([]byte{}, 0)
 
 type proxyEntry struct {
@@ -39,7 +34,7 @@ type Proxy struct {
 // For more control over the UDP socket, use ProxyConnectedSocket.
 // Applications may add custom header fields to the response header,
 // but MUST NOT call WriteHeader on the http.ResponseWriter.
-func (s *Proxy) Proxy(w http.ResponseWriter, r *Request) error {
+func (s *Proxy) Proxy(w http.ResponseWriter, r *ConnectUDPRequest) error {
 	if s.closed.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return net.ErrClosed
@@ -66,7 +61,7 @@ func (s *Proxy) Proxy(w http.ResponseWriter, r *Request) error {
 // Applications may add custom header fields to the response header,
 // but MUST NOT call WriteHeader on the http.ResponseWriter.
 // It closes the connection before returning.
-func (s *Proxy) ProxyConnectedSocket(w http.ResponseWriter, _ *Request, conn *net.UDPConn) error {
+func (s *Proxy) ProxyConnectedSocket(w http.ResponseWriter, _ *ConnectUDPRequest, conn *net.UDPConn) error {
 	if s.closed.Load() {
 		conn.Close()
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package masque
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,9 +13,12 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
+const capsuleHeader = "Capsule-Protocol"
+
 const (
-	requestProtocol = "connect-udp"
-	capsuleHeader   = "Capsule-Protocol"
+	connectUDPRequestProtocol    = "connect-udp"
+	connectUDPTemplateTargetHost = "target_host"
+	connectUDPTemplateTargetPort = "target_port"
 )
 
 var capsuleProtocolHeaderValue string
@@ -27,14 +31,14 @@ func init() {
 	capsuleProtocolHeaderValue = v
 }
 
-// Request is the parsed CONNECT-UDP request returned from ParseRequest.
+// ConnectUDPRequest is the parsed CONNECT-UDP request returned from ParseConnectUDPRequest.
 // Target is the target server that the client requests to connect to.
 // It can either be DNS name:port or an IP:port.
-type Request struct {
+type ConnectUDPRequest struct {
 	Target string
 }
 
-// RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
+// RequestParseError is returned from ParseConnectUDPRequest if parsing the CONNECT-UDP request fails.
 // It is recommended that the request is rejected with the corresponding HTTP status code.
 type RequestParseError struct {
 	HTTPStatus int
@@ -44,64 +48,70 @@ type RequestParseError struct {
 func (e *RequestParseError) Error() string { return e.Err.Error() }
 func (e *RequestParseError) Unwrap() error { return e.Err }
 
-// ParseRequest parses a CONNECT-UDP request.
-// The template is the URI template that clients will use to configure this UDP proxy.
-func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, error) {
+func verifyConnectUDPAndIPRequest(r *http.Request, template *uritemplate.Template) *RequestParseError {
 	u, err := url.Parse(template.Raw())
 	if err != nil {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusInternalServerError,
 			Err:        fmt.Errorf("failed to parse template: %w", err),
 		}
 	}
-
 	if r.Method != http.MethodConnect {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusMethodNotAllowed,
 			Err:        fmt.Errorf("expected CONNECT request, got %s", r.Method),
 		}
 	}
-	if r.Proto != requestProtocol {
-		return nil, &RequestParseError{
-			HTTPStatus: http.StatusNotImplemented,
-			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
-		}
-	}
 	if r.Host != u.Host {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("host in :authority (%s) does not match template host (%s)", r.Host, u.Host),
 		}
 	}
 	capsuleHeaderValues, ok := r.Header[capsuleHeader]
 	if !ok {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("missing Capsule-Protocol header"),
 		}
 	}
 	item, err := httpsfv.UnmarshalItem(capsuleHeaderValues)
 	if err != nil {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("invalid capsule header value: %s", capsuleHeaderValues),
 		}
 	}
 	if v, ok := item.Value.(bool); !ok {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("incorrect capsule header value type: %s", reflect.TypeOf(item.Value)),
 		}
 	} else if !v {
-		return nil, &RequestParseError{
+		return &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("incorrect capsule header value: %t", item.Value),
 		}
 	}
+	return nil
+}
+
+// ParseConnectUDPRequest parses a CONNECT-UDP request.
+// The template is the URI template that clients will use to configure this UDP proxy.
+func ParseConnectUDPRequest(r *http.Request, template *uritemplate.Template) (*ConnectUDPRequest, error) {
+	if r.Proto != connectUDPRequestProtocol {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusNotImplemented,
+			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
+		}
+	}
+	if err := verifyConnectUDPAndIPRequest(r, template); err != nil {
+		return nil, err
+	}
 
 	match := template.Match(r.URL.String())
-	targetHost := unescape(match.Get(uriTemplateTargetHost).String())
-	targetPortStr := match.Get(uriTemplateTargetPort).String()
+	targetHost := unescape(match.Get(connectUDPTemplateTargetHost).String())
+	targetPortStr := match.Get(connectUDPTemplateTargetPort).String()
 	if targetHost == "" || targetPortStr == "" {
 		return nil, &RequestParseError{
 			HTTPStatus: http.StatusBadRequest,
@@ -119,8 +129,30 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 			Err:        fmt.Errorf("failed to decode target_port: %w", err),
 		}
 	}
-	return &Request{Target: fmt.Sprintf("%s:%d", targetHost, targetPort)}, nil
+	return &ConnectUDPRequest{Target: fmt.Sprintf("%s:%d", targetHost, targetPort)}, nil
 }
 
 func escape(s string) string   { return strings.ReplaceAll(s, ":", "%3A") }
 func unescape(s string) string { return strings.ReplaceAll(s, "%3A", ":") }
+
+const connectIPRequestProtocol = "connect-ip"
+
+// ConnectIPRequest is the parsed CONNECT-IP request returned from ParseConnectIPRequest.
+// It currently doesn't have any fields, since masque-go doesn't support IP flow forwarding.
+type ConnectIPRequest struct{}
+
+func ParseConnectIPRequest(r *http.Request, template *uritemplate.Template) (*ConnectIPRequest, error) {
+	if len(template.Varnames()) > 0 {
+		return nil, errors.New("masque-go currently does not support IP flow forwarding")
+	}
+	if r.Proto != connectIPRequestProtocol {
+		return nil, &RequestParseError{
+			HTTPStatus: http.StatusNotImplemented,
+			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
+		}
+	}
+	if err := verifyConnectUDPAndIPRequest(r, template); err != nil {
+		return nil, err
+	}
+	return &ConnectIPRequest{}, nil
+}

--- a/request_test.go
+++ b/request_test.go
@@ -3,6 +3,7 @@ package masque
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/dunglas/httpsfv"
@@ -10,98 +11,139 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
-func TestRequestParsing(t *testing.T) {
+func newConnectUDPRequest(target string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.Method = http.MethodConnect
+	req.Proto = connectUDPRequestProtocol
+	req.Header.Add("Capsule-Protocol", capsuleProtocolHeaderValue)
+	return req
+}
+
+func newConnectIPRequest(target string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	req.Method = http.MethodConnect
+	req.Proto = connectIPRequestProtocol
+	req.Header.Add("Capsule-Protocol", capsuleProtocolHeaderValue)
+	return req
+}
+
+func TestConnectUDPRequestParsing(t *testing.T) {
 	template := uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}")
 
 	t.Run("valid request for a hostname", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=localhost&p=1337")
-		r, err := ParseRequest(req, template)
+		req := newConnectUDPRequest("https://localhost:1234/masque?h=localhost&p=1337")
+		r, err := ParseConnectUDPRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "localhost:1337")
 	})
 
 	t.Run("valid request for an IPv4 address", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=1.2.3.4&p=9999")
-		r, err := ParseRequest(req, template)
+		req := newConnectUDPRequest("https://localhost:1234/masque?h=1.2.3.4&p=9999")
+		r, err := ParseConnectUDPRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "1.2.3.4:9999")
 	})
 
 	t.Run("valid request for an IPv6 address", func(t *testing.T) {
-		req := newRequest(fmt.Sprintf("https://localhost:1234/masque?h=%s&p=1234", escape("::1")))
-		r, err := ParseRequest(req, template)
+		req := newConnectUDPRequest(fmt.Sprintf("https://localhost:1234/masque?h=%s&p=1234", escape("::1")))
+		r, err := ParseConnectUDPRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "[::1]:1234")
 	})
 
 	t.Run("wrong request method", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		req.Method = http.MethodHead
-		_, err := ParseRequest(req, template)
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "expected CONNECT request, got HEAD")
 		require.Equal(t, http.StatusMethodNotAllowed, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong protocol", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		req.Proto = "not-connect-udp"
-		_, err := ParseRequest(req, template)
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "unexpected protocol: not-connect-udp")
 		require.Equal(t, http.StatusNotImplemented, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong :authority", func(t *testing.T) {
-		req := newRequest("https://quic-go.net:1234/masque")
-		_, err := ParseRequest(req, template)
+		req := newConnectUDPRequest("https://quic-go.net:1234/masque")
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "host in :authority (quic-go.net:1234) does not match template host (localhost:1234)")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("missing Capsule-Protocol header", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		req.Header.Del("Capsule-Protocol")
-		_, err := ParseRequest(req, template)
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "missing Capsule-Protocol header")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		req.Header.Set("Capsule-Protocol", "🤡")
-		_, err := ParseRequest(req, template)
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "invalid capsule header value: [🤡]")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value type", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		req.Header.Set("Capsule-Protocol", "1")
-		_, err := ParseRequest(req, template)
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value type: int64")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque")
+		req := newConnectUDPRequest("https://localhost:1234/masque")
 		v, err := httpsfv.Marshal(httpsfv.NewItem(false))
 		require.NoError(t, err)
 		req.Header.Set("Capsule-Protocol", v)
-		_, err = ParseRequest(req, template)
+		_, err = ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value: false")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("missing target host", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=&p=1234")
-		_, err := ParseRequest(req, template)
+		req := newConnectUDPRequest("https://localhost:1234/masque?h=&p=1234")
+		_, err := ParseConnectUDPRequest(req, template)
 		require.EqualError(t, err, "expected target_host and target_port")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid target port", func(t *testing.T) {
-		req := newRequest("https://localhost:1234/masque?h=localhost&p=foobar")
-		_, err := ParseRequest(req, template)
+		req := newConnectUDPRequest("https://localhost:1234/masque?h=localhost&p=foobar")
+		_, err := ParseConnectUDPRequest(req, template)
 		require.ErrorContains(t, err, "failed to decode target_port")
 		require.Equal(t, http.StatusBadRequest, err.(*RequestParseError).HTTPStatus)
+	})
+}
+
+func TestConnectIPRequestParsing(t *testing.T) {
+	t.Run("valid request", func(t *testing.T) {
+		template := uritemplate.MustNew("https://localhost:1234/masque/ip")
+		req := newConnectIPRequest("https://localhost:1234/masque/ip")
+		r, err := ParseConnectIPRequest(req, template)
+		require.NoError(t, err)
+		require.Equal(t, &ConnectIPRequest{}, r)
+	})
+
+	t.Run("reject templates with variables", func(t *testing.T) {
+		template := uritemplate.MustNew("https://localhost:1234/masque/ip?t={target}&i={ipproto}")
+		req := newConnectIPRequest("https://localhost:1234/masque/ip?t=foobar&i=42")
+		_, err := ParseConnectIPRequest(req, template)
+		require.EqualError(t, err, "masque-go currently does not support IP flow forwarding")
+	})
+
+	t.Run("wrong protocol", func(t *testing.T) {
+		req := newConnectIPRequest("https://localhost:1234/masque")
+		req.Proto = "not-connect-ip"
+		_, err := ParseConnectIPRequest(req, uritemplate.MustNew("https://localhost:1234/masque/"))
+		require.EqualError(t, err, "unexpected protocol: not-connect-ip")
+		require.Equal(t, http.StatusNotImplemented, err.(*RequestParseError).HTTPStatus)
 	})
 }


### PR DESCRIPTION
Part of #63. Depends on #70.

This intentionally omits requests that define URI template variables, since we don't support IP flow forwarding yet.