### PR TITLE
remove the template parameter from the client

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -34,7 +34,6 @@ func main() {
 	}
 
 	cl := masque.Client{
-		Template: uritemplate.MustNew(proxyURITemplate),
 		QUICConfig: &quic.Config{
 			EnableDatagrams:   true,
 			InitialPacketSize: 1350,
@@ -52,7 +51,7 @@ func main() {
 				if err != nil {
 					return nil, err
 				}
-				pconn, _, err := cl.Dial(context.Background(), raddr)
+				pconn, _, err := cl.Dial(context.Background(), uritemplate.MustNew(proxyURITemplate), raddr)
 				if err != nil {
 					log.Fatal("dialing MASQUE failed:", err)
 				}


### PR DESCRIPTION
The same UDP proxy could offer proxying functionality at different paths (and therefore different templates), and we should be able to multiplex these on the same QUIC connection.