### PR TITLE
introduce a basic tracer

### DIFF
--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -74,7 +74,7 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		proxy.Proxy(w, req)
+		proxy.Proxy(w, req, nil)
 	})
 	go func() {
 		if err := server.Serve(conn); err != nil {
@@ -135,7 +135,7 @@ func TestProxyToHostname(t *testing.T) {
 		// In this test, we don't actually want to connect to quic-go.net
 		// Replace the target with the UDP echoer we spun up earlier.
 		req.Target = remoteServerConn.LocalAddr().String()
-		proxy.Proxy(w, req)
+		proxy.Proxy(w, req, nil)
 	})
 	go func() {
 		if err := server.Serve(conn); err != nil {
@@ -231,7 +231,7 @@ func TestProxyShutdown(t *testing.T) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		proxy.Proxy(w, req)
+		proxy.Proxy(w, req, nil)
 	})
 	go func() {
 		if err := server.Serve(conn); err != nil {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -75,7 +75,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 	})
 	r, err := ParseRequest(req, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
-	go p.Proxy(&http3ResponseWriter{ResponseWriter: rec, str: str}, r)
+	go p.Proxy(&http3ResponseWriter{ResponseWriter: rec, str: str}, r, nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	b := make([]byte, 100)
@@ -103,7 +103,7 @@ func TestProxyDialFailure(t *testing.T) {
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 
-	require.ErrorContains(t, p.Proxy(rec, req), "invalid port")
+	require.ErrorContains(t, p.Proxy(rec, req, nil), "invalid port")
 	require.Equal(t, http.StatusGatewayTimeout, rec.Code)
 }
 
@@ -117,7 +117,7 @@ func TestProxyingAfterClose(t *testing.T) {
 
 	t.Run("proxying", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		require.ErrorIs(t, p.Proxy(rec, req), net.ErrClosed)
+		require.ErrorIs(t, p.Proxy(rec, req, nil), net.ErrClosed)
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	})
 
@@ -125,7 +125,7 @@ func TestProxyingAfterClose(t *testing.T) {
 		rec := httptest.NewRecorder()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 		require.NoError(t, err)
-		require.ErrorIs(t, p.ProxyConnectedSocket(rec, req, conn), net.ErrClosed)
+		require.ErrorIs(t, p.ProxyConnectedSocket(rec, conn, nil), net.ErrClosed)
 		require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 	})
 }

--- a/tracer.go
+++ b/tracer.go
@@ -1,0 +1,13 @@
+package masque
+
+// A Tracer can be used to monitor the progress of a proxied connection.
+type Tracer struct {
+	// SentData is called when data is sent towards the target.
+	SentData func(n int)
+	// SentDirectionClosed is called when the send direction (towards the target) is closed.
+	SendDirectionClosed func()
+	// ReceivedData is called when data is received from the target.
+	ReceivedData func(n int)
+	// ReceiveDirectionClosed is called when the receive direction (from the target) is closed.
+	ReceiveDirectionClosed func()
+}


### PR DESCRIPTION
Resolves #59, in a more useful way than #62. Specifically, it allows the application to get an instantaneous notification about every proxied packet, not only an aggregate at the end of the connection.

Unfortunately, this is quite an annoying API change. The alternative would be to have a single `Tracer` on the `Proxy`, but this is way less powerful: it would only be possible to get the sum of all proxied connections.

---

**TODO**: add a few basic tests