### PR TITLE
Add ability to set http headers in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,8 @@ type Client struct {
 
 	// QUICConfig is the QUIC config used when dialing the QUIC connection.
 	QUICConfig *quic.Config
+	// Headers can be set to specify additional HTTP headers in the Extended CONNECT
+	Headers http.Header
 
 	dialOnce   sync.Once
 	dialErr    error
@@ -119,11 +121,17 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string) (net.PacketC
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to open request stream: %w", err)
 	}
+
+	if c.Headers == nil {
+		c.Headers = http.Header{}
+	}
+	c.Headers[http3.CapsuleProtocolHeader] = []string{capsuleProtocolHeaderValue}
+
 	if err := rstr.SendRequestHeader(&http.Request{
 		Method: http.MethodConnect,
 		Proto:  requestProtocol,
 		Host:   u.Host,
-		Header: http.Header{http3.CapsuleProtocolHeader: []string{capsuleProtocolHeaderValue}},
+		Header: c.Headers,
 		URL:    u,
 	}); err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to send request: %w", err)


### PR DESCRIPTION
This adds the ability to specify additional HTTP headers in the Extended Connect.

```golang
cl := masque.Client{
  QUICConfig:      quicConf,
  TLSClientConfig: tlsConf,
  Headers:         http.Header{"EXAMPLE_HEADER": []string{"example_header_value}},
}
tunnelConn, _, err := cl.Dial(
  context.Background(),
  uritemplate.MustNew(template),
  targetAddr,
)
```

