### PR TITLE
use math/rand/v2 instead of golang.org/x/exp/rand in tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"golang.org/x/exp/rand"
 	"io"
 	"log"
+	"math/rand/v2"
 	"os"
 	"testing"
 	"time"
@@ -148,9 +148,9 @@ func TestReadDeadline(t *testing.T) {
 			return nil, ctx.Err()
 		}).MinTimes(num)
 
-		for i := 0; i < num; i++ {
+		for range num {
 			// random duration between -5ms and 5ms
-			d := scaleDuration(maxDeadline - time.Duration(rand.Intn(int(2*maxDeadline))))
+			d := scaleDuration(maxDeadline - time.Duration(rand.Int64N(2*maxDeadline.Nanoseconds())))
 			t.Logf("setting deadline to %v", d)
 			require.NoError(t, conn.SetReadDeadline(time.Now().Add(d)))
 			_, _, err := conn.ReadFrom(make([]byte, 100))

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.4.0
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 )
 
 require (
@@ -21,6 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect


### PR DESCRIPTION
No functional change expected.