### PR TITLE
Fix connection tracking logic issues

### DIFF
--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package masque
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -30,6 +31,7 @@ func init() {
 // It can either be DNS name:port or an IP:port.
 type Request struct {
 	Target string
+	Body io.ReadCloser
 }
 
 // RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
@@ -115,7 +117,10 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 			Err:        fmt.Errorf("failed to decode target_port: %w", err),
 		}
 	}
-	return &Request{Target: fmt.Sprintf("%s:%d", targetHost, targetPort)}, nil
+	return &Request{
+		Target: fmt.Sprintf("%s:%d", targetHost, targetPort),
+		Body: r.Body,
+	}, nil
 }
 
 func escape(s string) string   { return strings.ReplaceAll(s, ":", "%3A") }

--- a/request.go
+++ b/request.go
@@ -2,7 +2,6 @@ package masque
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -32,7 +31,6 @@ func init() {
 type Request struct {
 	Target string
 	Host   string
-	Body   io.ReadCloser
 }
 
 // RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
@@ -121,7 +119,6 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 	return &Request{
 		Target: fmt.Sprintf("%s:%d", targetHost, targetPort),
 		Host:   r.Host,
-		Body:   r.Body,
 	}, nil
 }
 


### PR DESCRIPTION
The current proxy code contains a few minor logic issues related to connection tracking, which this change addresses:

A. Connections are never removed from the tracking map, creating a slow memory leak.
B. If Proxy.Close() races with Proxy.ProxyConnectedSocket(), it is possible that:
  1. ProxyConnectedSocket sees `s.closed.Load() == false`.
  2. Close() sets `s.closed` to true.
  3. Close() acquires `s.mx`
  4. ProxyConnectedSocket blocks acquiring `s.mx`
  5. Close() closes all pending connections, resets `s.conns`, and releases `s.mx`.
  6. ProxyConnectedSocket acquires `s.mx`, recreates `s.conns`, and proceeds with proxying.
  7. Close() blocks on `s.refCount.Wait()` until the client closes the connection.

This change resolves these issues in part by removing optimizations that rely on `atomic`.  It also includes some slight adjustments to support future implementation of the Capsule Protocol and other HTTP versions.