### PR TITLE
Refactor virtual connection as a thin wrapper around net.Pipe

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,8 +144,8 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string, raddr net.Ad
 			raddr = udpAddr
 		}
 	}
-
-	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr), rsp, nil
+	laddr := masqueAddr{c.conn.LocalAddr().String()}
+	return ProxiedPacketConn(rstr, rsp.Body, laddr, raddr), rsp, nil
 }
 
 // Extract the Proxy-Status next-hop value as a UDPAddr.

--- a/conn.go
+++ b/conn.go
@@ -1,16 +1,11 @@
 package masque
 
 import (
-	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"net"
-	"os"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
@@ -24,172 +19,85 @@ func (m masqueAddr) String() string  { return m.string }
 
 var _ net.Addr = masqueAddr{}
 
-type http3Stream interface {
-	io.ReadWriteCloser
-	ReceiveDatagram(context.Context) ([]byte, error)
-	SendDatagram([]byte) error
-	CancelRead(quic.StreamErrorCode)
+// Avoid allocating a buffer for each packet.
+var udpBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, maxUDPPayloadSize)
+		return &buf
+	},
 }
 
-var (
-	_ http3Stream = &http3.Stream{}
-	_ http3Stream = &http3.RequestStream{}
-)
-
-type proxiedConn struct {
-	str        http3Stream
+// packetConnWrapper converts a [net.Conn] from [net.Pipe]
+// into a [net.PacketConn] that can only be used for a single
+// destination.  The pipe is presumed to carry writes of
+// at most [maxUDPPayloadSize] bytes.
+type packetConnWrapper struct {
+	net.Conn
 	localAddr  net.Addr
 	remoteAddr net.Addr
-
-	closed   atomic.Bool // set when Close is called
-	readDone chan struct{}
-
-	deadlineMx        sync.Mutex
-	readCtx           context.Context
-	readCtxCancel     context.CancelFunc
-	deadline          time.Time
-	readDeadlineTimer *time.Timer
 }
 
-var _ net.PacketConn = &proxiedConn{}
+func (p packetConnWrapper) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, err := p.Read(b)
+	return n, p.RemoteAddr(), err
+}
 
-func newProxiedConn(str http3Stream, local, remote net.Addr) *proxiedConn {
-	c := &proxiedConn{
-		str:        str,
-		localAddr:  local,
-		remoteAddr: remote,
-		readDone:   make(chan struct{}),
+func (p packetConnWrapper) LocalAddr() net.Addr {
+	return p.localAddr
+}
+
+func (p packetConnWrapper) RemoteAddr() net.Addr {
+	return p.remoteAddr
+}
+
+func (p packetConnWrapper) WriteTo(b []byte, _ net.Addr) (int, error) {
+	return p.Write(b)
+}
+
+func (p packetConnWrapper) Read(b []byte) (int, error) {
+	if len(b) >= maxUDPPayloadSize {
+		return p.Conn.Read(b)
 	}
-	c.readCtx, c.readCtxCancel = context.WithCancel(context.Background())
+	// Ensure UDP-style truncation behavior when len(b) < maxUDPPayloadSize.
+	// Otherwise, large payloads would be fragmented instead of truncated.
+	buf := udpBufPool.Get().(*[]byte)
+	n, err := p.Conn.Read(*buf)
+	n = copy(b, (*buf)[:n])
+	udpBufPool.Put(buf)
+	return n, err
+}
+
+func (p packetConnWrapper) Write(b []byte) (int, error) {
+	if len(b) > maxUDPPayloadSize {
+		// net.Conn may fragment large writes instead of dropping them.
+		log.Printf("Dropping oversize UDP write")
+		return len(b), nil
+	}
+	return p.Conn.Write(b)
+}
+
+// ProxiedPacketConn converts an HTTP request and response stream, speaking
+// connect-udp, into a synthetic [net.PacketConn] of UDP packets.
+//
+// When the PacketConn is closed, the request and response streams will be closed.
+func ProxiedPacketConn(str DatagramSendReceiver, rsp io.ReadCloser, laddr, raddr net.Addr) net.PacketConn {
+	left, right := net.Pipe()
+
 	go func() {
-		defer close(c.readDone)
-		if err := skipCapsules(quicvarint.NewReader(str)); err != io.EOF && !c.closed.Load() {
-			log.Printf("reading from request stream failed: %v", err)
-		}
+		forwardUDP(str, rsp, right)
 		str.Close()
+		str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
 	}()
-	return c
-}
-
-func (c *proxiedConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
-start:
-	c.deadlineMx.Lock()
-	ctx := c.readCtx
-	c.deadlineMx.Unlock()
-	data, err := c.str.ReceiveDatagram(ctx)
-	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			return 0, nil, err
-		}
-		// The context is cancelled asynchronously (in a Go routine spawned from time.AfterFunc).
-		// We need to check if a new deadline has already been set.
-		c.deadlineMx.Lock()
-		restart := time.Now().Before(c.deadline)
-		c.deadlineMx.Unlock()
-		if restart {
-			goto start
-		}
-		return 0, nil, os.ErrDeadlineExceeded
-	}
-	contextID, n, err := quicvarint.Parse(data)
-	if err != nil {
-		return 0, nil, fmt.Errorf("masque: malformed datagram: %w", err)
-	}
-	if contextID != 0 {
-		// Drop this datagram. We currently only support proxying of UDP payloads.
-		goto start
-	}
-	// If b is too small, additional bytes are discarded.
-	// This mirrors the behavior of large UDP datagrams received on a UDP socket (on Linux).
-	return copy(b, data[n:]), c.remoteAddr, nil
-}
-
-// WriteTo sends a UDP datagram to the target.
-// The net.Addr parameter is ignored.
-func (c *proxiedConn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
-	data := make([]byte, 0, len(contextIDZero)+len(p))
-	data = append(data, contextIDZero...)
-	data = append(data, p...)
-	return len(p), c.str.SendDatagram(data)
-}
-
-func (c *proxiedConn) Close() error {
-	c.closed.Store(true)
-	c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
-	err := c.str.Close()
-	<-c.readDone
-	c.readCtxCancel()
-	c.deadlineMx.Lock()
-	if c.readDeadlineTimer != nil {
-		c.readDeadlineTimer.Stop()
-	}
-	c.deadlineMx.Unlock()
-	return err
-}
-
-func (c *proxiedConn) LocalAddr() net.Addr {
-	return c.localAddr
-}
-
-func (c *proxiedConn) RemoteAddr() net.Addr {
-	return c.remoteAddr
-}
-
-func (c *proxiedConn) SetDeadline(t time.Time) error {
-	_ = c.SetWriteDeadline(t)
-	return c.SetReadDeadline(t)
-}
-
-func (c *proxiedConn) SetReadDeadline(t time.Time) error {
-	c.deadlineMx.Lock()
-	defer c.deadlineMx.Unlock()
-
-	oldDeadline := c.deadline
-	c.deadline = t
-	now := time.Now()
-	// Stop the timer.
-	if t.IsZero() {
-		if c.readDeadlineTimer != nil && !c.readDeadlineTimer.Stop() {
-			<-c.readDeadlineTimer.C
-		}
-
-		return nil
-	}
-	// If the deadline already expired, cancel immediately.
-	if !t.After(now) {
-		c.readCtxCancel()
-		return nil
-	}
-	deadline := t.Sub(now)
-	// if we already have a timer, reset it
-	if c.readDeadlineTimer != nil {
-		// if that timer expired, create a new one
-		if now.Before(oldDeadline) {
-			c.readCtxCancel() // the old context might already have been cancelled, but that's not guaranteed
-			c.readCtx, c.readCtxCancel = context.WithCancel(context.Background())
-		}
-		c.readDeadlineTimer.Reset(deadline)
-	} else { // this is the first time the timer is set
-		c.readDeadlineTimer = time.AfterFunc(deadline, func() {
-			c.deadlineMx.Lock()
-			defer c.deadlineMx.Unlock()
-			if !c.deadline.IsZero() && c.deadline.Before(time.Now()) {
-				c.readCtxCancel()
-			}
-		})
-	}
-	return nil
-}
-
-func (c *proxiedConn) SetWriteDeadline(time.Time) error {
-	// TODO(#22): This is currently blocked on a change in quic-go's API.
-	return nil
+	return packetConnWrapper{Conn: left, localAddr: laddr, remoteAddr: raddr}
 }
 
 func skipCapsules(str quicvarint.Reader) error {
 	for {
 		ct, r, err := http3.ParseCapsule(str)
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
 			return err
 		}
 		log.Printf("skipping capsule of type %d", ct)

--- a/proxy.go
+++ b/proxy.go
@@ -44,6 +44,9 @@ func isCleanShutdownError(err error) bool {
 	if errors.As(err, &opErr) && opErr.Err.Error() == "use of closed network connection" {
 		return true
 	}
+	if errors.Is(err, io.ErrClosedPipe) {
+		return true
+	}
 
 	// These errors are expected when the connection is closed.
 	var h3Err *http3.Error


### PR DESCRIPTION
The current virtual connection struct `proxiedConn` implements the client side of CONNECT-UDP.  It also contains a great deal of logic to pair reads and writes using a channel, implement deadlines using timers, etc.  Most of this functionality is already available in `masque.Proxy` or `net.Pipe`.

This change reorganizes conn.go and proxy.go to share their implementation of the CONNECT-UDP protocol (which is logically symmetrical for clients and servers), using `net.Pipe` to reverse the direction on the client side.  This reduces the amount of code required in this package and ensures symmetry between the client and server implementations.

The only significant behavior change here is that calls to `ReceiveDatagram(ctx)` no longer pass a nontrivial context, so they cannot time out.  This implies one additional packet of buffering after a read deadline is exceeded.

The main motivation for this change is to enable a sensible implementation of the Capsule Protocol (see draft at https://github.com/bemasc/masque-go/pull/1)