### PR TITLE
remove unneeded gomock dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.uber.org/goleak v1.3.0
-	go.uber.org/mock v0.5.0
 )
 
 require (
@@ -16,6 +15,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
+	go.uber.org/mock v0.5.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.28.0 // indirect

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,0 @@
-//go:build tools
-
-package masque
-
-import (
-	_ "go.uber.org/mock/mockgen"
-)


### PR DESCRIPTION
#89 refactored our tests to not use mocks anymore. This also means that we don't need the gomock dependency anymore.