### PR TITLE
Expose remote address on the client's returned PacketConn

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
 
+	"github.com/dunglas/httpsfv"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 	"github.com/yosida95/uritemplate/v3"
@@ -51,7 +53,7 @@ func (c *Client) DialAddr(ctx context.Context, proxyTemplate *uritemplate.Templa
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
 	}
-	return c.dial(ctx, str)
+	return c.dial(ctx, str, masqueAddr{target})
 }
 
 // Dial dials a proxied connection to a target server.
@@ -63,10 +65,10 @@ func (c *Client) Dial(ctx context.Context, proxyTemplate *uritemplate.Template, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
 	}
-	return c.dial(ctx, str)
+	return c.dial(ctx, str, raddr)
 }
 
-func (c *Client) dial(ctx context.Context, expandedTemplate string) (net.PacketConn, *http.Response, error) {
+func (c *Client) dial(ctx context.Context, expandedTemplate string, raddr net.Addr) (net.PacketConn, *http.Response, error) {
 	u, err := url.Parse(expandedTemplate)
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to parse URI: %w", err)
@@ -136,7 +138,53 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string) (net.PacketC
 	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
 		return nil, rsp, fmt.Errorf("masque: server responded with %d", rsp.StatusCode)
 	}
-	return newProxiedConn(rstr, c.conn.LocalAddr()), rsp, nil
+
+	if _, udp := raddr.(*net.UDPAddr); !udp {
+		if udpAddr := nextHopAddr(rsp); udpAddr != nil {
+			raddr = udpAddr
+		}
+	}
+
+	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr), rsp, nil
+}
+
+// Extract the Proxy-Status next-hop value as a UDPAddr.
+func nextHopAddr(rsp *http.Response) *net.UDPAddr {
+	proxyStatusVals := rsp.Header.Values("Proxy-Status")
+	if len(proxyStatusVals) == 0 {
+		return nil
+	}
+	proxyStatus, err := httpsfv.UnmarshalItem(proxyStatusVals)
+	if err != nil {
+		log.Printf("bad Proxy-Status: %v", err)
+		return nil
+	}
+	nextHop, ok := proxyStatus.Params.Get("next-hop")
+	if !ok {
+		return nil
+	}
+	nextHopStr, ok := nextHop.(string)
+	if !ok {
+		log.Printf("non-string nextHop value")
+		return nil
+	}
+	if nextHopStr == "" {
+		return nil
+	}
+	host, port, err := net.SplitHostPort(nextHopStr)
+	if err != nil {
+		log.Printf("bad next-hop value: %v", err)
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil
+	}
+	portNum, err := net.LookupPort("udp", port)
+	if err != nil {
+		log.Printf("bad port: %v", err)
+	}
+	return &net.UDPAddr{IP: ip, Port: portNum}
 }
 
 // Close closes the connection to the proxy.

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -96,9 +96,15 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 	_, err = proxiedConn.WriteTo([]byte("foobar"), remoteServerConn.LocalAddr())
 	require.NoError(t, err)
 	b := make([]byte, 1500)
-	n, _, err := proxiedConn.ReadFrom(b)
+	n, raddr, err := proxiedConn.ReadFrom(b)
 	require.NoError(t, err)
 	require.Equal(t, []byte("foobar"), b[:n])
+
+	// Check raddr
+	expected := remoteServerConn.LocalAddr().(*net.UDPAddr)
+	observed := raddr.(*net.UDPAddr)
+	require.True(t, observed.IP.Equal(expected.IP))
+	require.Equal(t, expected.Port, observed.Port)
 }
 
 func TestProxyToHostname(t *testing.T) {
@@ -154,9 +160,15 @@ func TestProxyToHostname(t *testing.T) {
 	_, err = proxiedConn.WriteTo([]byte("foobar"), nil)
 	require.NoError(t, err)
 	b := make([]byte, 1500)
-	n, _, err := proxiedConn.ReadFrom(b)
+	n, raddr, err := proxiedConn.ReadFrom(b)
 	require.NoError(t, err)
 	require.Equal(t, []byte("foobar"), b[:n])
+
+	// Check raddr
+	expected := remoteServerConn.LocalAddr().(*net.UDPAddr)
+	observed := raddr.(*net.UDPAddr)
+	require.True(t, observed.IP.Equal(expected.IP))
+	require.Equal(t, expected.Port, observed.Port)
 }
 
 func TestProxyingRejected(t *testing.T) {


### PR DESCRIPTION
This change allows clients to learn the result of the proxy's DNS resolution by using the Proxy-Status's "next-hop" parameter to populate the remote address of the synthetic net.PacketConn returned by the client.