### PR TITLE
ci: remove 386 (32 bit x86)

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,12 +19,6 @@ jobs:
         env:
           TIMESCALE_FACTOR: 10
         run: go test -v -cover -coverprofile coverage.txt ./...
-      - name: Run tests (32 bit)
-        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
-        env:
-          TIMESCALE_FACTOR: 10
-          GOARCH: 386
-        run: go test -v -cover
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
As suggested by @MarcoPolo in https://github.com/quic-go/quic-go/pull/5352.