### PR TITLE
ci: enable Codecov test analysis

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,10 +15,12 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: go version
+      - name: Install go-junit-report
+        run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
       - name: Run tests
         env:
           TIMESCALE_FACTOR: 10
-        run: go test -v -cover -coverprofile coverage.txt ./...
+        run: go test -v -shuffle on -cover -coverprofile coverage.txt ./... 2>&1 | go-junit-report -set-exit-code -iocopy -out report.xml
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v7
@@ -27,5 +29,17 @@ jobs:
           GO: ${{ matrix.go }}
         with:
           files: coverage.txt
+          env_vars: OS,GO
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test report to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        env:
+          OS: ${{ matrix.os }}
+          GO: ${{ matrix.go }}
+        with:
+          report_type: test_results
+          name: Unit tests
+          files: report.xml
           env_vars: OS,GO
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
See https://github.com/quic-go/quic-go/pull/5210.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Codecov test analysis in the unit tests CI pipeline
> - Installs `go-junit-report` v2.1.0 and updates the test run command to shuffle tests and pipe output to generate `report.xml`
> - Adds a Codecov upload step that sends `report.xml` as test results with OS/Go environment metadata
> - Behavioral Change: job failure is now determined by `go-junit-report`'s parsed exit code (`-set-exit-code`) rather than the raw `go test` exit code
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8ccadb6. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->