### PR TITLE
README: fix link to documentation on quic-go.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # masque-go
 
-[![Documentation](https://img.shields.io/badge/docs-quic--go.net-red?style=flat)](https://quic-go.net/docs/masque)
+[![Documentation](https://img.shields.io/badge/docs-quic--go.net-red?style=flat)](https://quic-go.net/docs/connect-udp)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/quic-go/masque-go)](https://pkg.go.dev/github.com/quic-go/masque-go)
 [![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/masque-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/masque-go/)
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update README documentation badge link to quic-go.net/docs/connect-udp to fix broken reference
Change the Documentation badge target in [README.md](https://github.com/quic-go/masque-go/pull/115/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) from `quic-go.net/docs/masque` to `quic-go.net/docs/connect-udp`.

#### 📍Where to Start
Start with the badge hyperlink in [README.md](https://github.com/quic-go/masque-go/pull/115/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 9a3ebb5.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->