### PR TITLE
ci: run go fix as part of the lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         if: success() || failure() # run this step even if the previous one failed
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
       - name: Run go fix
-        if: (success() || failure()) && matrix.go == '1.26.x'
+        if: success() || failure() # run this step even if the previous one failed
         run: go fix -diff ./...
       - name: staticcheck
         if: success() || failure() # run this step even if the previous one failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install staticcheck
         if: success() || failure() # run this step even if the previous one failed
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+      - name: Run go fix
+        if: (success() || failure()) && matrix.go == '1.26.x'
+        run: go fix -diff ./...
       - name: staticcheck
         if: success() || failure() # run this step even if the previous one failed
         run: |

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -273,7 +273,7 @@ func TestProxyShutdown(t *testing.T) {
 	_, _, err = proxiedConn.ReadFrom(b)
 	require.Error(t, err)
 	var errored bool
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		if _, err := proxiedConn.WriteTo(b, remoteServerConn.LocalAddr()); err != nil {
 			errored = true
 			break


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `go fix -diff` step to the lint CI workflow
- Adds a `go fix -diff ./...` step to [lint.yml](.github/workflows/lint.yml) that runs after staticcheck, regardless of prior step outcome.
- Updates a counted `for` loop in [connect-udp_test.go](https://github.com/quic-go/masque-go/pull/125/files#diff-ba8110fe88a7aa7fc6762bedb24174da08eadc2363dd6f74dc8c4063083e4845) to use the range-over-integer form (`for range 10`), which `go fix` would flag.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d47ec62. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->