### PR TITLE
introduce a Transport and a ClientConn

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,109 +2,41 @@ package masque
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"net/url"
-	"strconv"
-	"sync"
 
-	"github.com/dunglas/httpsfv"
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-	"github.com/yosida95/uritemplate/v3"
+
+	"github.com/dunglas/httpsfv"
 )
 
-// defaultInitialPacketSize is an increased packet size used for the connection to the proxy.
-// This allows tunneling QUIC connections, which themselves have a minimum MTU requirement of 1200 bytes.
-const defaultInitialPacketSize = 1350
-
-// A Client establishes proxied connections to remote hosts, using a UDP proxy.
-// Multiple flows can be proxied via the same connection to the proxy.
-type Client struct {
-	// TLSClientConfig is the TLS client config used when dialing the QUIC connection to the proxy.
-	// It must set the "h3" ALPN.
-	TLSClientConfig *tls.Config
-
-	// QUICConfig is the QUIC config used when dialing the QUIC connection.
-	QUICConfig *quic.Config
-
-	dialOnce   sync.Once
-	dialErr    error
+// A ClientConn represents a connection to a single proxy server.
+// Multiple proxied connections can be established over a single ClientConn.
+type ClientConn struct {
 	conn       *quic.Conn
 	clientConn *http3.ClientConn
 }
 
-// DialAddr dials a proxied connection to a target server.
-// The target address is sent to the proxy, and the DNS resolution is left to the proxy.
-// The target must be given as a host:port.
-func (c *Client) DialAddr(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (net.PacketConn, *http.Response, error) {
-	host, port, err := net.SplitHostPort(target)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse target: %w", err)
-	}
-	str, err := proxyTemplate.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(host),
-		uriTemplateTargetPort: uritemplate.String(port),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
-	}
-	return c.dial(ctx, str, masqueAddr{target})
+// Dial dials a proxied connection to a target server over the proxy connection.
+func (c *ClientConn) Dial(req *http.Request) (*Conn, *http.Response, error) {
+	return c.dial(req, nil)
 }
 
-// Dial dials a proxied connection to a target server.
-func (c *Client) Dial(ctx context.Context, proxyTemplate *uritemplate.Template, raddr *net.UDPAddr) (net.PacketConn, *http.Response, error) {
-	str, err := proxyTemplate.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(raddr.IP.String()),
-		uriTemplateTargetPort: uritemplate.String(strconv.Itoa(raddr.Port)),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("masque: failed to expand Template: %w", err)
+func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *http.Response, error) {
+	if req == nil {
+		return nil, nil, errors.New("masque: nil request")
 	}
-	return c.dial(ctx, str, raddr)
-}
-
-func (c *Client) dial(ctx context.Context, expandedTemplate string, raddr net.Addr) (net.PacketConn, *http.Response, error) {
-	u, err := url.Parse(expandedTemplate)
-	if err != nil {
-		return nil, nil, fmt.Errorf("masque: failed to parse URI: %w", err)
+	if req.URL == nil {
+		return nil, nil, errors.New("masque: request URL is nil")
 	}
 
-	c.dialOnce.Do(func() {
-		quicConf := c.QUICConfig
-		if quicConf == nil {
-			quicConf = &quic.Config{
-				EnableDatagrams:   true,
-				InitialPacketSize: defaultInitialPacketSize,
-			}
-		}
-		if !quicConf.EnableDatagrams {
-			c.dialErr = errors.New("masque: QUICConfig needs to enable Datagrams")
-			return
-		}
-		tlsConf := c.TLSClientConfig
-		if tlsConf == nil {
-			tlsConf = &tls.Config{NextProtos: []string{http3.NextProtoH3}}
-		}
-		conn, err := quic.DialAddr(ctx, u.Host, tlsConf, quicConf)
-		if err != nil {
-			c.dialErr = fmt.Errorf("masque: dialing QUIC connection failed: %w", err)
-			return
-		}
-		c.conn = conn
-		tr := &http3.Transport{EnableDatagrams: true}
-		c.clientConn = tr.NewClientConn(conn)
-	})
-	if c.dialErr != nil {
-		return nil, nil, c.dialErr
-	}
 	select {
-	case <-ctx.Done():
-		return nil, nil, context.Cause(ctx)
+	case <-req.Context().Done():
+		return nil, nil, context.Cause(req.Context())
 	case <-c.clientConn.Context().Done():
 		return nil, nil, context.Cause(c.clientConn.Context())
 	case <-c.clientConn.ReceivedSettings():
@@ -117,17 +49,11 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string, raddr net.Ad
 		return nil, nil, errors.New("masque: server didn't enable Datagrams")
 	}
 
-	rstr, err := c.clientConn.OpenRequestStream(ctx)
+	rstr, err := c.clientConn.OpenRequestStream(req.Context())
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to open request stream: %w", err)
 	}
-	if err := rstr.SendRequestHeader(&http.Request{
-		Method: http.MethodConnect,
-		Proto:  requestProtocol,
-		Host:   u.Host,
-		Header: http.Header{http3.CapsuleProtocolHeader: []string{capsuleProtocolHeaderValue}},
-		URL:    u,
-	}); err != nil {
+	if err := rstr.SendRequestHeader(req); err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to send request: %w", err)
 	}
 	// TODO: optimistically return the connection
@@ -139,13 +65,14 @@ func (c *Client) dial(ctx context.Context, expandedTemplate string, raddr net.Ad
 		return nil, rsp, fmt.Errorf("masque: server responded with %d", rsp.StatusCode)
 	}
 
-	if _, udp := raddr.(*net.UDPAddr); !udp {
-		if udpAddr := nextHopAddr(rsp); udpAddr != nil {
-			raddr = udpAddr
-		}
+	var raddr net.Addr
+	if udpAddr := nextHopAddr(rsp); udpAddr != nil {
+		raddr = udpAddr
+	} else {
+		raddr = net.Addr(masqueAddr{req.URL.String()})
 	}
 
-	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr), rsp, nil
+	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr, closeConn), rsp, nil
 }
 
 // Extract the Proxy-Status next-hop value as a UDPAddr.
@@ -186,14 +113,4 @@ func nextHopAddr(rsp *http.Response) *net.UDPAddr {
 		return nil
 	}
 	return &net.UDPAddr{IP: ip, Port: portNum}
-}
-
-// Close closes the connection to the proxy.
-// This immediately shuts down all proxied flows.
-func (c *Client) Close() error {
-	c.dialOnce.Do(func() {}) // wait for existing calls to finish
-	if c.conn != nil {
-		return c.conn.CloseWithError(0, "")
-	}
-	return nil
 }

--- a/client.go
+++ b/client.go
@@ -54,6 +54,14 @@ func (c *ClientConn) dial(req *Request, closeConn func() error) (*Conn, *http.Re
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to open request stream: %w", err)
 	}
+
+	var keepStream bool
+	defer func() {
+		if !keepStream {
+			rstr.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
+			rstr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeNoError))
+		}
+	}()
 	if err := rstr.SendRequestHeader(httpReq); err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to send request: %w", err)
 	}
@@ -73,6 +81,7 @@ func (c *ClientConn) dial(req *Request, closeConn func() error) (*Conn, *http.Re
 		raddr = net.Addr(masqueAddr{req.target})
 	}
 
+	keepStream = true
 	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr, closeConn), rsp, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -33,6 +33,9 @@ func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *ht
 	if req.URL == nil {
 		return nil, nil, errors.New("masque: request URL is nil")
 	}
+	if req.Host == "" && req.URL.Host == "" {
+		return nil, nil, errors.New("masque: request needs a host")
+	}
 
 	select {
 	case <-req.Context().Done():

--- a/client.go
+++ b/client.go
@@ -36,6 +36,9 @@ func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *ht
 	if req.Host == "" && req.URL.Host == "" {
 		return nil, nil, errors.New("masque: request needs a host")
 	}
+	if c == nil || c.conn == nil || c.clientConn == nil {
+		return nil, nil, errors.New("masque: ClientConn not initialized")
+	}
 
 	select {
 	case <-req.Context().Done():

--- a/client.go
+++ b/client.go
@@ -68,6 +68,8 @@ func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *ht
 	var raddr net.Addr
 	if udpAddr := nextHopAddr(rsp); udpAddr != nil {
 		raddr = udpAddr
+	} else if target, ok := req.Context().Value(requestTargetContextKey{}).(string); ok && target != "" {
+		raddr = net.Addr(masqueAddr{target})
 	} else {
 		raddr = net.Addr(masqueAddr{req.URL.String()})
 	}

--- a/client.go
+++ b/client.go
@@ -22,27 +22,22 @@ type ClientConn struct {
 }
 
 // Dial dials a proxied connection to a target server over the proxy connection.
-func (c *ClientConn) Dial(req *http.Request) (*Conn, *http.Response, error) {
+func (c *ClientConn) Dial(req *Request) (*Conn, *http.Response, error) {
 	return c.dial(req, nil)
 }
 
-func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *http.Response, error) {
-	if req == nil {
-		return nil, nil, errors.New("masque: nil request")
-	}
-	if req.URL == nil {
+func (c *ClientConn) dial(req *Request, closeConn func() error) (*Conn, *http.Response, error) {
+	httpReq := req.req
+	if httpReq.URL == nil {
 		return nil, nil, errors.New("masque: request URL is nil")
 	}
-	if req.Host == "" && req.URL.Host == "" {
+	if httpReq.Host == "" && httpReq.URL.Host == "" {
 		return nil, nil, errors.New("masque: request needs a host")
-	}
-	if c == nil || c.conn == nil || c.clientConn == nil {
-		return nil, nil, errors.New("masque: ClientConn not initialized")
 	}
 
 	select {
-	case <-req.Context().Done():
-		return nil, nil, context.Cause(req.Context())
+	case <-httpReq.Context().Done():
+		return nil, nil, context.Cause(httpReq.Context())
 	case <-c.clientConn.Context().Done():
 		return nil, nil, context.Cause(c.clientConn.Context())
 	case <-c.clientConn.ReceivedSettings():
@@ -55,11 +50,11 @@ func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *ht
 		return nil, nil, errors.New("masque: server didn't enable Datagrams")
 	}
 
-	rstr, err := c.clientConn.OpenRequestStream(req.Context())
+	rstr, err := c.clientConn.OpenRequestStream(httpReq.Context())
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to open request stream: %w", err)
 	}
-	if err := rstr.SendRequestHeader(req); err != nil {
+	if err := rstr.SendRequestHeader(httpReq); err != nil {
 		return nil, nil, fmt.Errorf("masque: failed to send request: %w", err)
 	}
 	// TODO: optimistically return the connection
@@ -74,10 +69,8 @@ func (c *ClientConn) dial(req *http.Request, closeConn func() error) (*Conn, *ht
 	var raddr net.Addr
 	if udpAddr := nextHopAddr(rsp); udpAddr != nil {
 		raddr = udpAddr
-	} else if target, ok := req.Context().Value(requestTargetContextKey{}).(string); ok && target != "" {
-		raddr = net.Addr(masqueAddr{target})
 	} else {
-		raddr = net.Addr(masqueAddr{req.URL.String()})
+		raddr = net.Addr(masqueAddr{req.target})
 	}
 
 	return newProxiedConn(rstr, masqueAddr{c.conn.LocalAddr().String()}, raddr, closeConn), rsp, nil

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -33,7 +33,7 @@ func main() {
 		log.Fatal("usage: client -t <template> <url>")
 	}
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		QUICConfig: &quic.Config{
 			EnableDatagrams:   true,
 			InitialPacketSize: 1350,
@@ -51,7 +51,11 @@ func main() {
 				if err != nil {
 					return nil, err
 				}
-				pconn, _, err := cl.Dial(context.Background(), uritemplate.MustNew(proxyURITemplate), raddr)
+				req, err := masque.NewRequest(ctx, uritemplate.MustNew(proxyURITemplate), raddr.String())
+				if err != nil {
+					return nil, err
+				}
+				pconn, _, err := tr.Dial(req)
 				if err != nil {
 					log.Fatal("dialing MASQUE failed:", err)
 				}

--- a/conn.go
+++ b/conn.go
@@ -36,10 +36,11 @@ var (
 	_ http3Stream = &http3.RequestStream{}
 )
 
-type proxiedConn struct {
+type Conn struct {
 	str        http3Stream
 	localAddr  net.Addr
 	remoteAddr net.Addr
+	closeConn  func() error
 
 	closed   atomic.Bool // set when Close is called
 	readDone chan struct{}
@@ -51,13 +52,16 @@ type proxiedConn struct {
 	readDeadlineTimer *time.Timer
 }
 
-var _ net.PacketConn = &proxiedConn{}
+var _ net.PacketConn = &Conn{}
 
-func newProxiedConn(str http3Stream, local, remote net.Addr) *proxiedConn {
-	c := &proxiedConn{
+// closeConn is only used for QUIC connections dialed by [Transport.Dial].
+// It is nil for connections created through [Transport.NewClientConn]; callers close those QUIC connections themselves.
+func newProxiedConn(str http3Stream, local, remote net.Addr, closeConn func() error) *Conn {
+	c := &Conn{
 		str:        str,
 		localAddr:  local,
 		remoteAddr: remote,
+		closeConn:  closeConn,
 		readDone:   make(chan struct{}),
 	}
 	c.readCtx, c.readCtxCancel = context.WithCancel(context.Background())
@@ -71,7 +75,7 @@ func newProxiedConn(str http3Stream, local, remote net.Addr) *proxiedConn {
 	return c
 }
 
-func (c *proxiedConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
+func (c *Conn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 start:
 	c.deadlineMx.Lock()
 	ctx := c.readCtx
@@ -106,14 +110,14 @@ start:
 
 // WriteTo sends a UDP datagram to the target.
 // The net.Addr parameter is ignored.
-func (c *proxiedConn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
+func (c *Conn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
 	data := make([]byte, 0, len(contextIDZero)+len(p))
 	data = append(data, contextIDZero...)
 	data = append(data, p...)
 	return len(p), c.str.SendDatagram(data)
 }
 
-func (c *proxiedConn) Close() error {
+func (c *Conn) Close() error {
 	c.closed.Store(true)
 	c.str.CancelRead(quic.StreamErrorCode(http3.ErrCodeNoError))
 	err := c.str.Close()
@@ -124,23 +128,26 @@ func (c *proxiedConn) Close() error {
 		c.readDeadlineTimer.Stop()
 	}
 	c.deadlineMx.Unlock()
+	if c.closeConn != nil {
+		return errors.Join(err, c.closeConn())
+	}
 	return err
 }
 
-func (c *proxiedConn) LocalAddr() net.Addr {
+func (c *Conn) LocalAddr() net.Addr {
 	return c.localAddr
 }
 
-func (c *proxiedConn) RemoteAddr() net.Addr {
+func (c *Conn) RemoteAddr() net.Addr {
 	return c.remoteAddr
 }
 
-func (c *proxiedConn) SetDeadline(t time.Time) error {
+func (c *Conn) SetDeadline(t time.Time) error {
 	_ = c.SetWriteDeadline(t)
 	return c.SetReadDeadline(t)
 }
 
-func (c *proxiedConn) SetReadDeadline(t time.Time) error {
+func (c *Conn) SetReadDeadline(t time.Time) error {
 	c.deadlineMx.Lock()
 	defer c.deadlineMx.Unlock()
 
@@ -181,7 +188,7 @@ func (c *proxiedConn) SetReadDeadline(t time.Time) error {
 	return nil
 }
 
-func (c *proxiedConn) SetWriteDeadline(time.Time) error {
+func (c *Conn) SetWriteDeadline(time.Time) error {
 	// TODO(#22): This is currently blocked on a change in quic-go's API.
 	return nil
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -51,14 +51,16 @@ func setupProxiedConn(t *testing.T) (*http3.Stream, net.PacketConn) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+	target := targetConn.LocalAddr().String()
 	req, err := masque.NewRequest(ctx,
 		uritemplate.MustNew(fmt.Sprintf("https://localhost:%d/masque?h={target_host}&p={target_port}", serverConn.LocalAddr().(*net.UDPAddr).Port)),
-		targetConn.LocalAddr().String(),
+		target,
 	)
 	require.NoError(t, err)
 	conn, rsp, err := tr.Dial(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Equal(t, target, conn.RemoteAddr().String())
 	t.Cleanup(func() { conn.Close() })
 
 	var str *http3.Stream

--- a/conn_test.go
+++ b/conn_test.go
@@ -41,22 +41,22 @@ func setupProxiedConn(t *testing.T) (*http3.Stream, net.PacketConn) {
 	serverConn := newUDPConnLocalhost(t)
 	go server.Serve(serverConn)
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		TLSClientConfig: &tls.Config{
 			ClientCAs:          certPool,
 			NextProtos:         []string{http3.NextProtoH3},
 			InsecureSkipVerify: true,
 		},
 	}
-	t.Cleanup(func() { cl.Close() })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	conn, rsp, err := cl.Dial(
-		ctx,
+	req, err := masque.NewRequest(ctx,
 		uritemplate.MustNew(fmt.Sprintf("https://localhost:%d/masque?h={target_host}&p={target_port}", serverConn.LocalAddr().(*net.UDPAddr).Port)),
-		targetConn.LocalAddr().(*net.UDPAddr),
+		targetConn.LocalAddr().String(),
 	)
+	require.NoError(t, err)
+	conn, rsp, err := tr.Dial(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
 	t.Cleanup(func() { conn.Close() })

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -84,16 +84,14 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 		}
 	}()
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
 	}
-	defer cl.Close()
-	proxiedConn, _, err := cl.Dial(
-		context.Background(),
-		template,
-		remoteServerConn.LocalAddr().(*net.UDPAddr),
-	)
+	req, err := masque.NewRequest(context.Background(), template, remoteServerConn.LocalAddr().String())
 	require.NoError(t, err)
+	proxiedConn, _, err := tr.Dial(req)
+	require.NoError(t, err)
+	defer proxiedConn.Close()
 
 	rawQuery := <-rawQueryCh
 	// Verify the client encoded target_host per RFC 9298 (single percent-encoding).
@@ -139,6 +137,10 @@ func TestProxyToHostname(t *testing.T) {
 	proxy := masque.Proxy{}
 	defer proxy.Close()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
@@ -162,13 +164,16 @@ func TestProxyToHostname(t *testing.T) {
 		}
 	}()
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
 	}
-	defer cl.Close()
-	proxiedConn, rsp, err := cl.DialAddr(context.Background(), template, "quic-go.net:1234") // the proxy doesn't actually resolve this hostname
+	req, err := masque.NewRequest(context.Background(), template, "quic-go.net:1234") // the proxy doesn't actually resolve this hostname
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+	proxiedConn, rsp, err := tr.Dial(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	defer proxiedConn.Close()
 
 	_, err = proxiedConn.WriteTo([]byte("foobar"), nil)
 	require.NoError(t, err)
@@ -207,26 +212,23 @@ func TestProxyingRejected(t *testing.T) {
 		}
 	}()
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
 	}
-	defer cl.Close()
-	_, rsp, err := cl.DialAddr(context.Background(), template, "quic-go.net:1234") // the proxy doesn't actually resolve this hostname
+	req, err := masque.NewRequest(context.Background(), template, "quic-go.net:1234") // the proxy doesn't actually resolve this hostname
+	require.NoError(t, err)
+	_, rsp, err := tr.Dial(req)
 	require.Error(t, err)
 	require.Equal(t, http.StatusTeapot, rsp.StatusCode)
 }
 
 func TestProxyToHostnameMissingPort(t *testing.T) {
-	cl := masque.Client{
-		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
-	}
-	defer cl.Close()
-	_, rsp, err := cl.DialAddr(
+	req, err := masque.NewRequest(
 		context.Background(),
 		uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"),
 		"quic-go.net", // missing port
 	)
-	require.Nil(t, rsp)
+	require.Nil(t, req)
 	require.ErrorContains(t, err, "address quic-go.net: missing port in address")
 }
 
@@ -264,13 +266,15 @@ func TestProxyShutdown(t *testing.T) {
 		}
 	}()
 
-	cl := masque.Client{
+	tr := masque.Transport{
 		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
 	}
-	defer cl.Close()
-	proxiedConn, rsp, err := cl.Dial(context.Background(), template, remoteServerConn.LocalAddr().(*net.UDPAddr))
+	req, err := masque.NewRequest(context.Background(), template, remoteServerConn.LocalAddr().String())
+	require.NoError(t, err)
+	proxiedConn, rsp, err := tr.Dial(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	defer proxiedConn.Close()
 
 	_, err = proxiedConn.WriteTo([]byte("foobar"), remoteServerConn.LocalAddr())
 	require.NoError(t, err)

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -232,6 +232,14 @@ func TestProxyToHostnameMissingPort(t *testing.T) {
 	require.ErrorContains(t, err, "address quic-go.net: missing port in address")
 }
 
+func TestClientConnDialNoHost(t *testing.T) {
+	req, err := http.NewRequest(http.MethodConnect, "https:///masque?h=quic-go.net&p=1234", nil)
+	require.NoError(t, err)
+
+	_, _, err = new(masque.ClientConn).Dial(req)
+	require.ErrorContains(t, err, "request needs a host")
+}
+
 func TestProxyShutdown(t *testing.T) {
 	remoteServerConn := runEchoServer(t, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	defer remoteServerConn.Close()

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -169,7 +169,7 @@ func TestProxyToHostname(t *testing.T) {
 	}
 	req, err := masque.NewRequest(context.Background(), template, "quic-go.net:1234") // the proxy doesn't actually resolve this hostname
 	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer token")
+	req.Header().Set("Authorization", "Bearer token")
 	proxiedConn, rsp, err := tr.Dial(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
@@ -232,12 +232,40 @@ func TestProxyToHostnameMissingPort(t *testing.T) {
 	require.ErrorContains(t, err, "address quic-go.net: missing port in address")
 }
 
-func TestClientConnDialNoHost(t *testing.T) {
-	req, err := http.NewRequest(http.MethodConnect, "https:///masque?h=quic-go.net&p=1234", nil)
+func TestDialUsesRequestTargetAsRemoteAddr(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	require.NoError(t, err)
+	defer conn.Close()
 
-	_, _, err = new(masque.ClientConn).Dial(req)
-	require.ErrorContains(t, err, "request needs a host")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(http3.CapsuleProtocolHeader, "?1")
+		w.WriteHeader(http.StatusOK)
+	})
+	server := http3.Server{
+		TLSConfig:       tlsConf,
+		QUICConfig:      &quic.Config{EnableDatagrams: true},
+		EnableDatagrams: true,
+		Handler:         mux,
+	}
+	defer server.Close()
+	go func() {
+		if err := server.Serve(conn); err != nil {
+			return
+		}
+	}()
+
+	template := uritemplate.MustNew(fmt.Sprintf("https://localhost:%d/masque?h={target_host}&p={target_port}", conn.LocalAddr().(*net.UDPAddr).Port))
+	req, err := masque.NewRequest(context.Background(), template, "quic-go.net:1234")
+	require.NoError(t, err)
+	tr := masque.Transport{
+		TLSClientConfig: &tls.Config{ClientCAs: certPool, NextProtos: []string{http3.NextProtoH3}, InsecureSkipVerify: true},
+	}
+	proxiedConn, rsp, err := tr.Dial(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	defer proxiedConn.Close()
+	require.Equal(t, "quic-go.net:1234", proxiedConn.RemoteAddr().String())
 }
 
 func TestProxyShutdown(t *testing.T) {

--- a/proxy.go
+++ b/proxy.go
@@ -15,11 +15,6 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
-const (
-	uriTemplateTargetHost = "target_host"
-	uriTemplateTargetPort = "target_port"
-)
-
 const maxUDPPayloadSize = 1500
 
 var contextIDZero = quicvarint.Append([]byte{}, 0)

--- a/proxy_request.go
+++ b/proxy_request.go
@@ -13,18 +13,6 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
-const requestProtocol = "connect-udp"
-
-var capsuleProtocolHeaderValue string
-
-func init() {
-	v, err := httpsfv.Marshal(httpsfv.NewItem(true))
-	if err != nil {
-		panic(fmt.Sprintf("failed to marshal capsule protocol header value: %v", err))
-	}
-	capsuleProtocolHeaderValue = v
-}
-
 // ProxyRequest is the parsed CONNECT-UDP request returned from ParseProxyRequest.
 // Target is the target server that the client requests to connect to.
 // It can either be DNS name:port or an IP:port.

--- a/request.go
+++ b/request.go
@@ -27,7 +27,8 @@ func init() {
 	capsuleProtocolHeaderValue = v
 }
 
-// Request is a CONNECT-UDP request.
+// Request is a CONNECT-UDP request created by NewRequest.
+// The zero value is not valid.
 type Request struct {
 	req    *http.Request
 	target string

--- a/request.go
+++ b/request.go
@@ -1,0 +1,62 @@
+package masque
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/dunglas/httpsfv"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/yosida95/uritemplate/v3"
+)
+
+const (
+	requestProtocol       = "connect-udp"
+	uriTemplateTargetHost = "target_host"
+	uriTemplateTargetPort = "target_port"
+)
+
+var capsuleProtocolHeaderValue string
+
+func init() {
+	v, err := httpsfv.Marshal(httpsfv.NewItem(true))
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal capsule protocol header value: %v", err))
+	}
+	capsuleProtocolHeaderValue = v
+}
+
+// Request is a CONNECT-UDP request.
+type Request struct {
+	req    *http.Request
+	target string
+}
+
+// NewRequest creates a CONNECT-UDP request for the given target.
+// The target must be given as a host:port.
+func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (*Request, error) {
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return nil, fmt.Errorf("masque: failed to parse target: %w", err)
+	}
+	str, err := proxyTemplate.Expand(uritemplate.Values{
+		uriTemplateTargetHost: uritemplate.String(host),
+		uriTemplateTargetPort: uritemplate.String(port),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("masque: failed to expand Template: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodConnect, str, nil)
+	if err != nil {
+		return nil, fmt.Errorf("masque: failed to create request: %w", err)
+	}
+	req.Proto = requestProtocol
+	req.Host = req.URL.Host
+	req.Header.Set(http3.CapsuleProtocolHeader, capsuleProtocolHeaderValue)
+	return &Request{req: req, target: target}, nil
+}
+
+// Header returns the HTTP header fields sent with the CONNECT-UDP request.
+// Callers may add custom headers before dialing.
+func (r *Request) Header() http.Header { return r.req.Header }

--- a/test_helper_test.go
+++ b/test_helper_test.go
@@ -83,6 +83,10 @@ func newUDPConnLocalhost(t testing.TB) *net.UDPConn {
 }
 
 func newConnPair(t *testing.T) (client, server *quic.Conn) {
+	return newConnPairWithDatagrams(t, true)
+}
+
+func newConnPairWithDatagrams(t *testing.T, enableDatagrams bool) (client, server *quic.Conn) {
 	t.Helper()
 
 	ln, err := quic.ListenEarly(
@@ -91,7 +95,7 @@ func newConnPair(t *testing.T) (client, server *quic.Conn) {
 		&quic.Config{
 			InitialStreamReceiveWindow:     1 << 60,
 			InitialConnectionReceiveWindow: 1 << 60,
-			EnableDatagrams:                true,
+			EnableDatagrams:                enableDatagrams,
 		},
 	)
 	require.NoError(t, err)
@@ -107,10 +111,12 @@ func newConnPair(t *testing.T) (client, server *quic.Conn) {
 			NextProtos: []string{http3.NextProtoH3},
 			RootCAs:    certPool,
 		},
-		&quic.Config{EnableDatagrams: true},
+		&quic.Config{EnableDatagrams: enableDatagrams},
 	)
 	require.NoError(t, err)
-	require.True(t, cl.ConnectionState().SupportsDatagrams.Remote)
+	if enableDatagrams {
+		require.True(t, cl.ConnectionState().SupportsDatagrams.Remote)
+	}
 	t.Cleanup(func() { cl.CloseWithError(0, "") })
 
 	conn, err := ln.Accept(ctx)
@@ -118,7 +124,9 @@ func newConnPair(t *testing.T) (client, server *quic.Conn) {
 	t.Cleanup(func() { conn.CloseWithError(0, "") })
 	select {
 	case <-conn.HandshakeComplete():
-		require.True(t, conn.ConnectionState().SupportsDatagrams.Remote)
+		if enableDatagrams {
+			require.True(t, conn.ConnectionState().SupportsDatagrams.Remote)
+		}
 	case <-ctx.Done():
 		t.Fatal("timeout")
 	}

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,110 @@
+package masque
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/yosida95/uritemplate/v3"
+)
+
+// defaultInitialPacketSize is an increased packet size used for the connection to the proxy.
+// This allows tunneling QUIC connections, which themselves have a minimum MTU requirement of 1200 bytes.
+const defaultInitialPacketSize = 1350
+
+// NewRequest creates a CONNECT-UDP request for the given target.
+// The target must be given as a host:port.
+func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (*http.Request, error) {
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target: %w", err)
+	}
+	str, err := proxyTemplate.Expand(uritemplate.Values{
+		uriTemplateTargetHost: uritemplate.String(host),
+		uriTemplateTargetPort: uritemplate.String(port),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("masque: failed to expand Template: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodConnect, str, nil)
+	if err != nil {
+		return nil, fmt.Errorf("masque: failed to create request: %w", err)
+	}
+	req.Proto = requestProtocol
+	req.Host = req.URL.Host
+	req.Header.Set(http3.CapsuleProtocolHeader, capsuleProtocolHeaderValue)
+	return req, nil
+}
+
+// A Transport establishes proxied connections to multiple remote hosts.
+type Transport struct {
+	// TLSClientConfig is the TLS client config used when dialing the QUIC connection to the proxy.
+	// It must set the "h3" ALPN.
+	TLSClientConfig *tls.Config
+
+	// QUICConfig is the QUIC config used when dialing the QUIC connection.
+	QUICConfig *quic.Config
+
+	// DialAddr dials the QUIC connection to the proxy.
+	// If unset, quic.DialAddr is used.
+	DialAddr func(ctx context.Context, addr string, tlsConf *tls.Config, quicConf *quic.Config) (*quic.Conn, error)
+}
+
+// Dial is a shortcut that opens a QUIC connection to the proxy and then dials a proxied connection.
+// Closing the returned Conn also closes the QUIC connection to the proxy.
+// More advanced use cases, including multiple proxied connections via one proxy connection,
+// should dial a new QUIC connection and use [Transport.NewClientConn].
+func (t *Transport) Dial(req *http.Request) (*Conn, *http.Response, error) {
+	if req == nil {
+		return nil, nil, errors.New("masque: nil request")
+	}
+	if req.URL == nil || req.URL.Host == "" {
+		return nil, nil, errors.New("masque: request URL needs a host")
+	}
+
+	quicConf := t.QUICConfig
+	if quicConf == nil {
+		quicConf = &quic.Config{
+			EnableDatagrams:   true,
+			InitialPacketSize: defaultInitialPacketSize,
+		}
+	}
+	if !quicConf.EnableDatagrams {
+		return nil, nil, errors.New("masque: QUICConfig needs to enable Datagrams")
+	}
+	tlsConf := t.TLSClientConfig
+	if tlsConf == nil {
+		tlsConf = &tls.Config{NextProtos: []string{http3.NextProtoH3}}
+	}
+	dial := t.DialAddr
+	if dial == nil {
+		dial = quic.DialAddr
+	}
+	conn, err := dial(req.Context(), req.URL.Host, tlsConf, quicConf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("masque: dialing QUIC connection failed: %w", err)
+	}
+	c := t.NewClientConn(conn)
+	pconn, rsp, err := c.dial(req, func() error { return conn.CloseWithError(0, "") })
+	if err != nil {
+		conn.CloseWithError(0, "")
+		return nil, rsp, err
+	}
+	return pconn, rsp, nil
+}
+
+// NewClientConn creates a client connection for an already established QUIC connection.
+// The caller owns the QUIC connection and closes it when done.
+func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
+	tr := &http3.Transport{EnableDatagrams: true}
+	return &ClientConn{
+		conn:       conn,
+		clientConn: tr.NewClientConn(conn),
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -25,7 +25,7 @@ type requestTargetContextKey struct{}
 func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (*http.Request, error) {
 	host, port, err := net.SplitHostPort(target)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse target: %w", err)
+		return nil, fmt.Errorf("masque: failed to parse target: %w", err)
 	}
 	str, err := proxyTemplate.Expand(uritemplate.Values{
 		uriTemplateTargetHost: uritemplate.String(host),

--- a/transport.go
+++ b/transport.go
@@ -61,7 +61,11 @@ func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: dialing QUIC connection failed: %w", err)
 	}
-	c := t.NewClientConn(conn)
+	c, err := t.NewClientConn(conn)
+	if err != nil {
+		conn.CloseWithError(0, "")
+		return nil, nil, err
+	}
 	pconn, rsp, err := c.dial(req, func() error { return conn.CloseWithError(0, "") })
 	if err != nil {
 		conn.CloseWithError(0, "")
@@ -71,11 +75,15 @@ func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
 }
 
 // NewClientConn creates a client connection for an already established QUIC connection.
+// It returns an error if the QUIC connection didn't negotiate datagram support.
 // The caller owns the QUIC connection and closes it when done.
-func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
+func (t *Transport) NewClientConn(conn *quic.Conn) (*ClientConn, error) {
+	if datagrams := conn.ConnectionState().SupportsDatagrams; !datagrams.Local || !datagrams.Remote {
+		return nil, errors.New("masque: QUIC connection needs Datagram support")
+	}
 	tr := &http3.Transport{EnableDatagrams: true}
 	return &ClientConn{
 		conn:       conn,
 		clientConn: tr.NewClientConn(conn),
-	}
+	}, nil
 }

--- a/transport.go
+++ b/transport.go
@@ -18,6 +18,8 @@ import (
 // This allows tunneling QUIC connections, which themselves have a minimum MTU requirement of 1200 bytes.
 const defaultInitialPacketSize = 1350
 
+type requestTargetContextKey struct{}
+
 // NewRequest creates a CONNECT-UDP request for the given target.
 // The target must be given as a host:port.
 func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (*http.Request, error) {
@@ -32,6 +34,7 @@ func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target
 	if err != nil {
 		return nil, fmt.Errorf("masque: failed to expand Template: %w", err)
 	}
+	ctx = context.WithValue(ctx, requestTargetContextKey{}, target)
 	req, err := http.NewRequestWithContext(ctx, http.MethodConnect, str, nil)
 	if err != nil {
 		return nil, fmt.Errorf("masque: failed to create request: %w", err)

--- a/transport.go
+++ b/transport.go
@@ -5,45 +5,15 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
-
-	"github.com/yosida95/uritemplate/v3"
 )
 
 // defaultInitialPacketSize is an increased packet size used for the connection to the proxy.
 // This allows tunneling QUIC connections, which themselves have a minimum MTU requirement of 1200 bytes.
 const defaultInitialPacketSize = 1350
-
-type requestTargetContextKey struct{}
-
-// NewRequest creates a CONNECT-UDP request for the given target.
-// The target must be given as a host:port.
-func NewRequest(ctx context.Context, proxyTemplate *uritemplate.Template, target string) (*http.Request, error) {
-	host, port, err := net.SplitHostPort(target)
-	if err != nil {
-		return nil, fmt.Errorf("masque: failed to parse target: %w", err)
-	}
-	str, err := proxyTemplate.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(host),
-		uriTemplateTargetPort: uritemplate.String(port),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("masque: failed to expand Template: %w", err)
-	}
-	ctx = context.WithValue(ctx, requestTargetContextKey{}, target)
-	req, err := http.NewRequestWithContext(ctx, http.MethodConnect, str, nil)
-	if err != nil {
-		return nil, fmt.Errorf("masque: failed to create request: %w", err)
-	}
-	req.Proto = requestProtocol
-	req.Host = req.URL.Host
-	req.Header.Set(http3.CapsuleProtocolHeader, capsuleProtocolHeaderValue)
-	return req, nil
-}
 
 // A Transport establishes proxied connections to multiple remote hosts.
 type Transport struct {
@@ -63,11 +33,9 @@ type Transport struct {
 // Closing the returned Conn also closes the QUIC connection to the proxy.
 // More advanced use cases, including multiple proxied connections via one proxy connection,
 // should dial a new QUIC connection and use [Transport.NewClientConn].
-func (t *Transport) Dial(req *http.Request) (*Conn, *http.Response, error) {
-	if req == nil {
-		return nil, nil, errors.New("masque: nil request")
-	}
-	if req.URL == nil || req.URL.Host == "" {
+func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
+	httpReq := req.req
+	if httpReq.URL == nil || httpReq.URL.Host == "" {
 		return nil, nil, errors.New("masque: request URL needs a host")
 	}
 
@@ -89,7 +57,7 @@ func (t *Transport) Dial(req *http.Request) (*Conn, *http.Response, error) {
 	if dial == nil {
 		dial = quic.DialAddr
 	}
-	conn, err := dial(req.Context(), req.URL.Host, tlsConf, quicConf)
+	conn, err := dial(httpReq.Context(), httpReq.URL.Host, tlsConf, quicConf)
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: dialing QUIC connection failed: %w", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,15 @@
+package masque_test
+
+import (
+	"testing"
+
+	"github.com/quic-go/masque-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientConnRequiresQUICDatagrams(t *testing.T) {
+	conn, _ := newConnPairWithDatagrams(t, false)
+
+	_, err := new(masque.Transport).NewClientConn(conn)
+	require.ErrorContains(t, err, "Datagram support")
+}


### PR DESCRIPTION
This PR implements the minimum version of the API discussed in #123. Closes #85.

@bemasc @EthanHeilman @anthoturc @fernandol-nvidia @fortuna Would be great if you could try this out and see if this now solves your use case.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `Transport` and `ClientConn` types to replace the `Client` dialing API
> - Replaces the old `Client` type with `Transport` and `ClientConn`. `Transport.Dial` takes a prepared `Request` and returns a `Conn`, closing the underlying QUIC connection when the `Conn` is closed. `Transport.NewClientConn` wraps an existing QUIC connection.
> - Adds a `Request` type and `NewRequest` constructor in [request.go](https://github.com/quic-go/masque-go/pull/126/files#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cec) that validates the target, expands the URI template, and sets required CONNECT-UDP headers. `Request.Header` allows callers to add custom headers (e.g., Authorization) before dialing.
> - Renames `proxiedConn` to `Conn` in [conn.go](https://github.com/quic-go/masque-go/pull/126/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654) and adds an optional `closeConn` callback invoked on `Conn.Close` for cascading closure of the proxy QUIC connection.
> - `ClientConn.Dial` takes a prepared `http.Request`, waits for HTTP/3 settings, requires Extended CONNECT and Datagram support, and sets `Conn.RemoteAddr` from the Proxy-Status next-hop when present.
> - Risk: the previous `Client.Dial`, `Client.DialAddr`, and `Client.Close` methods are removed; all callers must migrate to `NewRequest` + `Transport.Dial`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54e167f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->