### PR TITLE
fix encoding of IPv6 hosts

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,7 +59,7 @@ func (c *Client) DialAddr(ctx context.Context, proxyTemplate *uritemplate.Templa
 // Dial dials a proxied connection to a target server.
 func (c *Client) Dial(ctx context.Context, proxyTemplate *uritemplate.Template, raddr *net.UDPAddr) (net.PacketConn, *http.Response, error) {
 	str, err := proxyTemplate.Expand(uritemplate.Values{
-		uriTemplateTargetHost: uritemplate.String(escape(raddr.IP.String())),
+		uriTemplateTargetHost: uritemplate.String(raddr.IP.String()),
 		uriTemplateTargetPort: uritemplate.String(strconv.Itoa(raddr.Port)),
 	})
 	if err != nil {

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -67,7 +67,9 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 	defer server.Close()
 	proxy := masque.Proxy{}
 	defer proxy.Close()
+	rawQueryCh := make(chan string, 1)
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
+		rawQueryCh <- r.URL.RawQuery
 		req, err := masque.ParseRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
@@ -92,6 +94,15 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 		remoteServerConn.LocalAddr().(*net.UDPAddr),
 	)
 	require.NoError(t, err)
+
+	rawQuery := <-rawQueryCh
+	// Verify the client encoded target_host per RFC 9298 (single percent-encoding).
+	require.NotContains(t, rawQuery, "%25", "target_host must not be double percent-encoded")
+	if addr.IP.To4() == nil { // IPv6: colons MUST be percent-encoded, e.g. "::1" -> "%3A%3A1"
+		require.Contains(t, rawQuery, "h=%3A%3A1")
+	} else {
+		require.Contains(t, rawQuery, "h="+addr.IP.String())
+	}
 
 	_, err = proxiedConn.WriteTo([]byte("foobar"), remoteServerConn.LocalAddr())
 	require.NoError(t, err)

--- a/request.go
+++ b/request.go
@@ -97,7 +97,7 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 	}
 
 	match := template.Match(r.URL.String())
-	targetHost := unescape(match.Get(uriTemplateTargetHost).String())
+	targetHost := match.Get(uriTemplateTargetHost).String()
 	targetPortStr := match.Get(uriTemplateTargetPort).String()
 	if targetHost == "" || targetPortStr == "" {
 		return nil, &RequestParseError{
@@ -121,6 +121,3 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 		Host:   r.Host,
 	}, nil
 }
-
-func escape(s string) string   { return strings.ReplaceAll(s, ":", "%3A") }
-func unescape(s string) string { return strings.ReplaceAll(s, "%3A", ":") }


### PR DESCRIPTION
yosida95/uritemplate/v3 already takes care of the RFC 6570 template expansion, so we don’t have to do it manually in this repo.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double percent-encoding of IPv6 addresses in CONNECT-UDP requests
> - Removes custom `escape`/`unescape` helpers from [client.go](https://github.com/quic-go/masque-go/pull/128/files#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cf) and [request.go](https://github.com/quic-go/masque-go/pull/128/files#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cec) that were pre-encoding `:` in IPv6 addresses as `%3A` before URI template expansion, causing double percent-encoding (e.g. `%253A`) in outgoing requests.
> - `Client.Dial` now passes `raddr.IP.String()` directly as `target_host`, and `ParseRequest` takes the value directly from the template match without reversing any custom encoding.
> - Adds assertions in [connect-udp_test.go](https://github.com/quic-go/masque-go/pull/128/files#diff-ba8110fe88a7aa7fc6762bedb24174da08eadc2363dd6f74dc8c4063083e4845) to verify `target_host` is not double-encoded and that IPv6 colons appear as `%3A` in the raw query.
> - Behavioral Change: servers and clients that previously relied on the custom `%3A`-to-`:` translation will now receive standard single percent-encoded IPv6 addresses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d7160c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->