### PR TITLE
rename Request to ProxyRequest

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -54,9 +54,9 @@ func main() {
 		log.Fatalf("failed to parse URI template: %v", err)
 	}
 	http.HandleFunc(u.Path, func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
-			var perr *masque.RequestParseError
+			var perr *masque.ProxyRequestParseError
 			if errors.As(err, &perr) {
 				w.WriteHeader(perr.HTTPStatus)
 				return

--- a/connect-udp_test.go
+++ b/connect-udp_test.go
@@ -70,7 +70,7 @@ func testProxyToIP(t *testing.T, addr *net.UDPAddr) {
 	rawQueryCh := make(chan string, 1)
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
 		rawQueryCh <- r.URL.RawQuery
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -139,7 +139,7 @@ func TestProxyToHostname(t *testing.T) {
 	proxy := masque.Proxy{}
 	defer proxy.Close()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)
@@ -250,7 +250,7 @@ func TestProxyShutdown(t *testing.T) {
 	defer server.Close()
 	proxy := masque.Proxy{}
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
 			t.Log("Upgrade failed:", err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/proxy.go
+++ b/proxy.go
@@ -83,7 +83,7 @@ func dnsErrorToProxyStatus(proxyStatus *httpsfv.Item, dnsError *net.DNSError) {
 // For more control over the UDP socket, use ProxyConnectedSocket.
 // Applications may add custom header fields to the response header,
 // but MUST NOT call WriteHeader on the http.ResponseWriter.
-func (s *Proxy) Proxy(w http.ResponseWriter, r *Request) error {
+func (s *Proxy) Proxy(w http.ResponseWriter, r *ProxyRequest) error {
 	s.mx.Lock()
 	if s.closed {
 		s.mx.Unlock()
@@ -139,7 +139,7 @@ func (s *Proxy) Proxy(w http.ResponseWriter, r *Request) error {
 // Applications may add custom header fields such as Proxy-Status
 // to the response header, but MUST NOT call WriteHeader on the
 // http.ResponseWriter. It closes the connection before returning.
-func (s *Proxy) ProxyConnectedSocket(w http.ResponseWriter, _ *Request, conn *net.UDPConn) error {
+func (s *Proxy) ProxyConnectedSocket(w http.ResponseWriter, _ *ProxyRequest, conn *net.UDPConn) error {
 	s.mx.Lock()
 	if s.closed {
 		s.mx.Unlock()

--- a/proxy_request.go
+++ b/proxy_request.go
@@ -25,49 +25,49 @@ func init() {
 	capsuleProtocolHeaderValue = v
 }
 
-// Request is the parsed CONNECT-UDP request returned from ParseRequest.
+// ProxyRequest is the parsed CONNECT-UDP request returned from ParseProxyRequest.
 // Target is the target server that the client requests to connect to.
 // It can either be DNS name:port or an IP:port.
-type Request struct {
+type ProxyRequest struct {
 	Target string
 	Host   string
 }
 
-// RequestParseError is returned from ParseRequest if parsing the CONNECT-UDP request fails.
+// ProxyRequestParseError is returned from ParseProxyRequest if parsing the CONNECT-UDP request fails.
 // It is recommended that the request is rejected with the corresponding HTTP status code.
-type RequestParseError struct {
+type ProxyRequestParseError struct {
 	HTTPStatus int
 	Err        error
 }
 
-func (e *RequestParseError) Error() string { return e.Err.Error() }
-func (e *RequestParseError) Unwrap() error { return e.Err }
+func (e *ProxyRequestParseError) Error() string { return e.Err.Error() }
+func (e *ProxyRequestParseError) Unwrap() error { return e.Err }
 
-// ParseRequest parses a CONNECT-UDP request.
+// ParseProxyRequest parses a CONNECT-UDP request.
 // The template is the URI template that clients will use to configure this UDP proxy.
-func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, error) {
+func ParseProxyRequest(r *http.Request, template *uritemplate.Template) (*ProxyRequest, error) {
 	u, err := url.Parse(template.Raw())
 	if err != nil {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusInternalServerError,
 			Err:        fmt.Errorf("failed to parse template: %w", err),
 		}
 	}
 
 	if r.Method != http.MethodConnect {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusMethodNotAllowed,
 			Err:        fmt.Errorf("expected CONNECT request, got %s", r.Method),
 		}
 	}
 	if r.Proto != requestProtocol {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusNotImplemented,
 			Err:        fmt.Errorf("unexpected protocol: %s", r.Proto),
 		}
 	}
 	if r.Host != u.Host {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("host in :authority (%s) does not match template host (%s)", r.Host, u.Host),
 		}
@@ -78,18 +78,18 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 	if ok {
 		item, err := httpsfv.UnmarshalItem(capsuleHeaderValues)
 		if err != nil {
-			return nil, &RequestParseError{
+			return nil, &ProxyRequestParseError{
 				HTTPStatus: http.StatusBadRequest,
 				Err:        fmt.Errorf("invalid capsule header value: %s", capsuleHeaderValues),
 			}
 		}
 		if v, ok := item.Value.(bool); !ok {
-			return nil, &RequestParseError{
+			return nil, &ProxyRequestParseError{
 				HTTPStatus: http.StatusBadRequest,
 				Err:        fmt.Errorf("incorrect capsule header value type: %s", reflect.TypeOf(item.Value)),
 			}
 		} else if !v {
-			return nil, &RequestParseError{
+			return nil, &ProxyRequestParseError{
 				HTTPStatus: http.StatusBadRequest,
 				Err:        fmt.Errorf("incorrect capsule header value: %t", item.Value),
 			}
@@ -100,7 +100,7 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 	targetHost := match.Get(uriTemplateTargetHost).String()
 	targetPortStr := match.Get(uriTemplateTargetPort).String()
 	if targetHost == "" || targetPortStr == "" {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("expected target_host and target_port"),
 		}
@@ -111,12 +111,12 @@ func ParseRequest(r *http.Request, template *uritemplate.Template) (*Request, er
 	}
 	targetPort, err := strconv.Atoi(targetPortStr)
 	if err != nil {
-		return nil, &RequestParseError{
+		return nil, &ProxyRequestParseError{
 			HTTPStatus: http.StatusBadRequest,
 			Err:        fmt.Errorf("failed to decode target_port: %w", err),
 		}
 	}
-	return &Request{
+	return &ProxyRequest{
 		Target: fmt.Sprintf("%s:%d", targetHost, targetPort),
 		Host:   r.Host,
 	}, nil

--- a/proxy_request_test.go
+++ b/proxy_request_test.go
@@ -14,28 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func escape(s string) string { return strings.ReplaceAll(s, ":", "%3A") }
-
-func TestRequestParsing(t *testing.T) {
+func TestProxyRequestParsing(t *testing.T) {
 	template := uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}")
 
 	t.Run("valid request for a hostname", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque?h=localhost&p=1337")
-		r, err := masque.ParseRequest(req, template)
+		r, err := masque.ParseProxyRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "localhost:1337")
 	})
 
 	t.Run("valid request for an IPv4 address", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque?h=1.2.3.4&p=9999")
-		r, err := masque.ParseRequest(req, template)
+		r, err := masque.ParseProxyRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "1.2.3.4:9999")
 	})
 
 	t.Run("valid request for an IPv6 address", func(t *testing.T) {
-		req := newRequest(fmt.Sprintf("https://localhost:1234/masque?h=%s&p=1234", escape("::1")))
-		r, err := masque.ParseRequest(req, template)
+		req := newRequest(fmt.Sprintf(
+			"https://localhost:1234/masque?h=%s&p=1234",
+			strings.ReplaceAll("::1", ":", "%3A"),
+		))
+		r, err := masque.ParseProxyRequest(req, template)
 		require.NoError(t, err)
 		require.Equal(t, r.Target, "[::1]:1234")
 	})
@@ -43,47 +44,47 @@ func TestRequestParsing(t *testing.T) {
 	t.Run("valid request, without the Capsule-Protocol header", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque?h=localhost&p=1337")
 		req.Header.Del(http3.CapsuleProtocolHeader)
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.NoError(t, err)
 	})
 
 	t.Run("wrong request method", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Method = http.MethodHead
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "expected CONNECT request, got HEAD")
-		require.Equal(t, http.StatusMethodNotAllowed, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusMethodNotAllowed, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong protocol", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Proto = "not-connect-udp"
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "unexpected protocol: not-connect-udp")
-		require.Equal(t, http.StatusNotImplemented, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusNotImplemented, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("wrong :authority", func(t *testing.T) {
 		req := newRequest("https://quic-go.net:1234/masque")
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "host in :authority (quic-go.net:1234) does not match template host (localhost:1234)")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Header.Set(http3.CapsuleProtocolHeader, "🤡")
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "invalid capsule header value: [🤡]")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value type", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque")
 		req.Header.Set(http3.CapsuleProtocolHeader, "1")
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value type: int64")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid Capsule-Protocol header value", func(t *testing.T) {
@@ -91,22 +92,22 @@ func TestRequestParsing(t *testing.T) {
 		v, err := httpsfv.Marshal(httpsfv.NewItem(false))
 		require.NoError(t, err)
 		req.Header.Set(http3.CapsuleProtocolHeader, v)
-		_, err = masque.ParseRequest(req, template)
+		_, err = masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "incorrect capsule header value: false")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("missing target host", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque?h=&p=1234")
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.EqualError(t, err, "expected target_host and target_port")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 
 	t.Run("invalid target port", func(t *testing.T) {
 		req := newRequest("https://localhost:1234/masque?h=localhost&p=foobar")
-		_, err := masque.ParseRequest(req, template)
+		_, err := masque.ParseProxyRequest(req, template)
 		require.ErrorContains(t, err, "failed to decode target_port")
-		require.Equal(t, http.StatusBadRequest, err.(*masque.RequestParseError).HTTPStatus)
+		require.Equal(t, http.StatusBadRequest, err.(*masque.ProxyRequestParseError).HTTPStatus)
 	})
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -40,7 +40,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 	p := masque.Proxy{}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/masque", func(w http.ResponseWriter, r *http.Request) {
-		req, err := masque.ParseRequest(r, template)
+		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
 			t.Logf("error parsing request: %v", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -111,7 +111,7 @@ func TestProxyCloseProxiedConn(t *testing.T) {
 func TestProxyBadPort(t *testing.T) {
 	p := masque.Proxy{}
 	r := newRequest("https://localhost:1234/masque?h=localhost&p=70000") // invalid port number
-	req, err := masque.ParseRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
+	req, err := masque.ParseProxyRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 
@@ -129,7 +129,7 @@ func TestProxyBadPort(t *testing.T) {
 func TestProxyNXDOMAIN(t *testing.T) {
 	p := masque.Proxy{}
 	r := newRequest("https://localhost:1234/masque?h=nxdomain.test&p=12345") // invalid port number
-	req, err := masque.ParseRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
+	req, err := masque.ParseProxyRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 
@@ -150,7 +150,7 @@ func TestProxyingAfterClose(t *testing.T) {
 	require.NoError(t, p.Close())
 
 	r := newRequest("https://localhost:1234/masque?h=localhost&p=1234")
-	req, err := masque.ParseRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
+	req, err := masque.ParseProxyRequest(r, uritemplate.MustNew("https://localhost:1234/masque?h={target_host}&p={target_port}"))
 	require.NoError(t, err)
 
 	t.Run("proxying", func(t *testing.T) {


### PR DESCRIPTION
The new API (#123) will use `Request` for client-side requests. We therefore need to vacate this term on the proxy side. Therefore, we're renaming it to `ProxyRequest`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `Request` to `ProxyRequest` and `ParseRequest` to `ParseProxyRequest` in the masque package
> Renames the `Request` type to `ProxyRequest`, `RequestParseError` to `ProxyRequestParseError`, and `ParseRequest` to `ParseProxyRequest` across the package. No fields, logic, or behavior change — this is a pure API rename for clarity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db61fcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->