### PR TITLE
update to Go 1.27, drop Go 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
       - name: Check for //go:build ignore in .go files
         run: |
           IGNORED_FILES=$(grep -rl '//go:build ignore' . --include='*.go') || true
@@ -35,7 +35,7 @@ jobs:
         run: go vet ./...
       - name: Install staticcheck
         if: success() || failure() # run this step even if the previous one failed
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
       - name: Run go fix
         if: success() || failure() # run this step even if the previous one failed
         run: go fix -diff ./...

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.25.x", "1.26.x" ]
+        go: [ "1.26.x", "1.27.x" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     steps:

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -56,8 +56,7 @@ func main() {
 	http.HandleFunc(u.Path, func(w http.ResponseWriter, r *http.Request) {
 		req, err := masque.ParseProxyRequest(r, template)
 		if err != nil {
-			var perr *masque.ProxyRequestParseError
-			if errors.As(err, &perr) {
+			if perr, ok := errors.AsType[*masque.ProxyRequestParseError](err); ok {
 				w.WriteHeader(perr.HTTPStatus)
 				return
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quic-go/masque-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/dunglas/httpsfv v1.1.0

--- a/proxy.go
+++ b/proxy.go
@@ -43,8 +43,7 @@ func errToStatus(err error) int {
 		// Consistent with RFC 9209 Section 2.3.1.
 		return http.StatusGatewayTimeout
 	}
-	var dnsError *net.DNSError
-	if errors.As(err, &dnsError) {
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
 		// Recommended by RFC 9209 Section 2.3.2.
 		return http.StatusBadGateway
 	}
@@ -104,8 +103,7 @@ func (s *Proxy) Proxy(w http.ResponseWriter, r *ProxyRequest) error {
 
 	addr, err := net.ResolveUDPAddr("udp", r.Target)
 	if err != nil {
-		var dnsError *net.DNSError
-		if errors.As(err, &dnsError) {
+		if dnsError, ok := errors.AsType[*net.DNSError](err); ok {
 			dnsErrorToProxyStatus(&proxyStatus, dnsError)
 		}
 		err = writeProxyStatus(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated the project’s supported Go versions through 1.27.
  - Improved compatibility with the latest Go tooling and static analysis checks.

- **Bug Fixes**
  - Preserved accurate handling of proxy request parsing and DNS-related errors.
  - DNS failures continue to return the appropriate gateway error response.

- **Maintenance**
  - Updated automated testing and code-quality workflows to cover the latest supported Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump Go to 1.27, drop 1.25, and switch to generic `errors.AsType`
> - Updates CI workflows to run lint and unit tests on Go 1.26.x and 1.27.x, and bumps `staticcheck` to v0.8.1
> - Sets the module language version to 1.26.0 in [go.mod](https://github.com/quic-go/masque-go/pull/135/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6)
> - Replaces `errors.As` with generic `errors.AsType` for `*masque.ProxyRequestParseError` in [main.go](https://github.com/quic-go/masque-go/pull/135/files#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52a) and for `*net.DNSError` in [proxy.go](https://github.com/quic-go/masque-go/pull/135/files#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499)
> - Risk: `errors.AsType` is a newer generic API; verify callers still get the expected typed value and HTTP status mapping behavior is unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c0037d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->