### PR TITLE
default to port 443 when dialing a portless proxy URL

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/quic-go/quic-go"
@@ -57,7 +58,11 @@ func (t *Transport) Dial(req *Request) (*Conn, *http.Response, error) {
 	if dial == nil {
 		dial = quic.DialAddr
 	}
-	conn, err := dial(httpReq.Context(), httpReq.URL.Host, tlsConf, quicConf)
+	addr := httpReq.URL.Host
+	if httpReq.URL.Port() == "" {
+		addr = net.JoinHostPort(httpReq.URL.Hostname(), "443")
+	}
+	conn, err := dial(httpReq.Context(), addr, tlsConf, quicConf)
 	if err != nil {
 		return nil, nil, fmt.Errorf("masque: dialing QUIC connection failed: %w", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,11 +1,31 @@
 package masque_test
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
 	"testing"
 
 	"github.com/quic-go/masque-go"
+	"github.com/quic-go/quic-go"
 	"github.com/stretchr/testify/require"
+	"github.com/yosida95/uritemplate/v3"
 )
+
+func TestTransportAddsDefaultPort(t *testing.T) {
+	req, err := masque.NewRequest(t.Context(), uritemplate.MustNew("https://proxy.example/masque?h={target_host}&p={target_port}"), "target.example:443")
+	require.NoError(t, err)
+
+	dialErr := errors.New("dial stopped")
+	tr := masque.Transport{
+		DialAddr: func(_ context.Context, addr string, _ *tls.Config, _ *quic.Config) (*quic.Conn, error) {
+			require.Equal(t, "proxy.example:443", addr)
+			return nil, dialErr
+		},
+	}
+	_, _, err = tr.Dial(req)
+	require.ErrorIs(t, err, dialErr)
+}
 
 func TestNewClientConnRequiresQUICDatagrams(t *testing.T) {
 	conn, _ := newConnPairWithDatagrams(t, false)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Default to port 443 when dialing a portless proxy URL in `Transport.Dial`
Fixes a failure when the proxy URL omits a port. `Transport.Dial` now uses `net.JoinHostPort` to append `:443` when no explicit port is present, instead of dialing the bare host. Adds a test asserting the computed address is `proxy.example:443`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd9109d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling for host-only proxy URLs by automatically using port 443.
  - Preserved existing ports when they are explicitly included in the URL.
  - Added validation to ensure the correct proxy address is used during connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->